### PR TITLE
Add Hisi to supported encoder/decoder.

### DIFF
--- a/sdk/android/api/org/webrtc/HardwareVideoDecoderFactory.java
+++ b/sdk/android/api/org/webrtc/HardwareVideoDecoderFactory.java
@@ -14,6 +14,7 @@ import static org.webrtc.MediaCodecUtils.EXYNOS_PREFIX;
 import static org.webrtc.MediaCodecUtils.INTEL_PREFIX;
 import static org.webrtc.MediaCodecUtils.NVIDIA_PREFIX;
 import static org.webrtc.MediaCodecUtils.QCOM_PREFIX;
+import static org.webrtc.MediaCodecUtils.HISI_PREFIX;
 
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecInfo.CodecCapabilities;
@@ -128,14 +129,19 @@ public class HardwareVideoDecoderFactory implements VideoDecoderFactory {
       case VP8:
         // QCOM, Intel, Exynos, and Nvidia all supported for VP8.
         return name.startsWith(QCOM_PREFIX) || name.startsWith(INTEL_PREFIX)
-            || name.startsWith(EXYNOS_PREFIX) || name.startsWith(NVIDIA_PREFIX);
+            || name.startsWith(EXYNOS_PREFIX) || name.startsWith(NVIDIA_PREFIX)
+            // Hisi seems to support VP8.
+            || name.startsWith(HISI_PREFIX);
       case VP9:
         // QCOM and Exynos supported for VP9.
-        return name.startsWith(QCOM_PREFIX) || name.startsWith(EXYNOS_PREFIX);
+        return name.startsWith(QCOM_PREFIX) || name.startsWith(EXYNOS_PREFIX)
+            // Hisi seems to support VP9.
+            || name.startsWith(HISI_PREFIX);
       case H264:
         // QCOM, Intel, and Exynos supported for H264.
         return name.startsWith(QCOM_PREFIX) || name.startsWith(INTEL_PREFIX)
-            || name.startsWith(EXYNOS_PREFIX);
+            // Hisi seems to support H264.
+            || name.startsWith(EXYNOS_PREFIX) || name.startsWith(HISI_PREFIX);
       default:
         return false;
     }

--- a/sdk/android/api/org/webrtc/HardwareVideoEncoderFactory.java
+++ b/sdk/android/api/org/webrtc/HardwareVideoEncoderFactory.java
@@ -13,6 +13,7 @@ package org.webrtc;
 import static org.webrtc.MediaCodecUtils.EXYNOS_PREFIX;
 import static org.webrtc.MediaCodecUtils.INTEL_PREFIX;
 import static org.webrtc.MediaCodecUtils.QCOM_PREFIX;
+import static org.webrtc.MediaCodecUtils.HISI_PREFIX;
 
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
@@ -179,12 +180,15 @@ public class HardwareVideoEncoderFactory implements VideoEncoderFactory {
         || (name.startsWith(EXYNOS_PREFIX) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
         // Intel Vp8 encoder is supported in LOLLIPOP or later, with the intel encoder enabled.
         || (name.startsWith(INTEL_PREFIX) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-               && enableIntelVp8Encoder);
+               && enableIntelVp8Encoder)
+        // Hisi Vp8 encoder seems to be supported. Needs more testing.
+        || (name.startsWith(HISI_PREFIX) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT);
   }
 
   private boolean isHardwareSupportedInCurrentSdkVp9(MediaCodecInfo info) {
     String name = info.getName();
-    return (name.startsWith(QCOM_PREFIX) || name.startsWith(EXYNOS_PREFIX))
+    return (name.startsWith(QCOM_PREFIX) || name.startsWith(EXYNOS_PREFIX) || name.startsWith(HISI_PREFIX))
+        // Just redo an old change on MediaCodecVideoEncoder. Needs more testing.
         // Both QCOM and Exynos VP9 encoders are supported in N or later.
         && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N;
   }
@@ -199,7 +203,9 @@ public class HardwareVideoEncoderFactory implements VideoEncoderFactory {
     return (name.startsWith(QCOM_PREFIX) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
         // Exynos H264 encoder is supported in LOLLIPOP or later.
         || (name.startsWith(EXYNOS_PREFIX)
-               && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
+               && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+        // Hisi H264 encoder seems to be supported. Needs more testing.
+        || (name.startsWith(HISI_PREFIX) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT);
   }
 
   private int getKeyFrameIntervalSec(VideoCodecType type) {

--- a/sdk/android/api/org/webrtc/MediaCodecVideoDecoder.java
+++ b/sdk/android/api/org/webrtc/MediaCodecVideoDecoder.java
@@ -140,7 +140,8 @@ public class MediaCodecVideoDecoder {
     VIDEO_CODEC_UNKNOWN,
     VIDEO_CODEC_VP8,
     VIDEO_CODEC_VP9,
-    VIDEO_CODEC_H264;
+    VIDEO_CODEC_H264,
+    VIDEO_CODEC_H265;
 
     @CalledByNative("VideoCodecType")
     static VideoCodecType fromNativeIndex(int nativeIndex) {
@@ -170,6 +171,7 @@ public class MediaCodecVideoDecoder {
   private static final String VP8_MIME_TYPE = "video/x-vnd.on2.vp8";
   private static final String VP9_MIME_TYPE = "video/x-vnd.on2.vp9";
   private static final String H264_MIME_TYPE = "video/avc";
+  private static final String H265_MIME_TYPE = "video/hevc";
   // List of supported HW VP8 decoders.
   private static final String[] supportedVp8HwCodecPrefixes() {
     ArrayList<String> supportedPrefixes = new ArrayList<String>();
@@ -197,6 +199,9 @@ public class MediaCodecVideoDecoder {
     }
     return supportedPrefixes.toArray(new String[supportedPrefixes.size()]);
   }
+
+  // TODO(zhanghe): add other decoders after checking.
+  private static final String[] supportedH265HwCodecPrefixes = {"OMX.qcom."};
 
   // List of supported HW H.264 high profile decoders.
   private static final String supportedQcomH264HighProfileHwCodecPrefix = "OMX.qcom.";
@@ -282,6 +287,11 @@ public class MediaCodecVideoDecoder {
     hwDecoderDisabledTypes.add(H264_MIME_TYPE);
   }
 
+  public static void disableH265HwCodec() {
+    Logging.w(TAG, "H.265 decoding is disabled by application.");
+    hwDecoderDisabledTypes.add(H265_MIME_TYPE);
+  }
+
   // Functions to query if HW decoding is supported.
   public static boolean isVp8HwSupported() {
     return !hwDecoderDisabledTypes.contains(VP8_MIME_TYPE)
@@ -322,6 +332,12 @@ public class MediaCodecVideoDecoder {
       return true;
     }
     return false;
+  }
+
+  @CalledByNativeUnchecked
+  public static boolean isH265HwSupported() {
+    return !hwDecoderDisabledTypes.contains(H265_MIME_TYPE)
+        && (findDecoder(H265_MIME_TYPE, supportedH265HwCodecPrefixes) != null);
   }
 
   public static void printStackTrace() {
@@ -439,6 +455,9 @@ public class MediaCodecVideoDecoder {
     } else if (type == VideoCodecType.VIDEO_CODEC_H264) {
       mime = H264_MIME_TYPE;
       supportedCodecPrefixes = supportedH264HwCodecPrefixes();
+    }  else if (type == VideoCodecType.VIDEO_CODEC_H265) {
+      mime = H265_MIME_TYPE;
+      supportedCodecPrefixes = supportedH265HwCodecPrefixes;
     } else {
       throw new RuntimeException("initDecode: Non-supported codec " + type);
     }

--- a/sdk/android/src/java/org/webrtc/MediaCodecUtils.java
+++ b/sdk/android/src/java/org/webrtc/MediaCodecUtils.java
@@ -30,6 +30,7 @@ class MediaCodecUtils {
   static final String INTEL_PREFIX = "OMX.Intel.";
   static final String NVIDIA_PREFIX = "OMX.Nvidia.";
   static final String QCOM_PREFIX = "OMX.qcom.";
+  static final String HISI_PREFIX = "OMX.hisi.";
 
   // NV12 color format supported by QCOM codec, but not declared in MediaCodec -
   // see /hardware/qcom/media/mm-core/inc/OMX_QCOMExtns.h


### PR DESCRIPTION
It seems Hisi encoder and decoder are supported. We still need more testing on it. 

We used to enable all OMX encoder/decoder except the one that is blacklisted. However, white list might be more safe than black list. It also minimizes the change we made to WebRTC lib. So i'm not redoing the old changes made for MediaCodecVideoEncoder and MediaCodecVideoDecoder