### PR TITLE
WIP: [Do Not Merge]Enable partial-output packetization for slice-based encoding

### DIFF
--- a/call/rtp_video_sender.cc
+++ b/call/rtp_video_sender.cc
@@ -324,7 +324,9 @@ EncodedImageCallback::Result RtpVideoSender::OnEncodedImage(
   RTC_DCHECK_LT(stream_index, rtp_modules_.size());
   RTPVideoHeader rtp_video_header = params_[stream_index].GetRtpVideoHeader(
       encoded_image, codec_specific_info, shared_frame_id_);
-
+  if (codec_specific_info->codecSpecific.H264.last_fragment_in_frame)
+    absl::get<RTPVideoHeaderH264>(rtp_video_header.video_type_header)
+        .has_last_fragement = true;
   uint32_t frame_id;
   if (!rtp_modules_[stream_index]->Sending()) {
     // The payload router could be active but this module isn't sending.

--- a/modules/rtp_rtcp/source/rtp_format.h
+++ b/modules/rtp_rtcp/source/rtp_format.h
@@ -35,7 +35,7 @@ class RtpPacketizer {
   virtual size_t SetPayloadData(
       const uint8_t* payload_data,
       size_t payload_size,
-      const RTPFragmentationHeader* fragmentation) = 0;
+      const RTPFragmentationHeader* fragmentation, bool end_of_frame) = 0;
 
   // Get the next payload with payload header.
   // Write payload and set marker bit of the |packet|.

--- a/modules/rtp_rtcp/source/rtp_format_h265.cc
+++ b/modules/rtp_rtcp/source/rtp_format_h265.cc
@@ -117,7 +117,8 @@ RtpPacketizerH265::Fragment::Fragment(const Fragment& fragment)
 size_t RtpPacketizerH265::SetPayloadData(
     const uint8_t* payload_data,
     size_t payload_size,
-    const RTPFragmentationHeader* fragmentation) {
+    const RTPFragmentationHeader* fragmentation,
+    bool /*end_of_frame*/) {
   RTC_DCHECK(packets_.empty());
   RTC_DCHECK(input_fragments_.empty());
   RTC_DCHECK(fragmentation);

--- a/modules/rtp_rtcp/source/rtp_format_h265.h
+++ b/modules/rtp_rtcp/source/rtp_format_h265.h
@@ -25,7 +25,7 @@ class RtpPacketizerH265 : public RtpPacketizer {
 
   size_t SetPayloadData(const uint8_t* payload_data,
                         size_t payload_size,
-                        const RTPFragmentationHeader* fragmentation) override;
+                        const RTPFragmentationHeader* fragmentation, bool end_of_frame) override;
 
   // Get the next payload with H.265 payload header.
   // buffer is a pointer to where the output will be written.

--- a/modules/rtp_rtcp/source/rtp_format_video_generic.cc
+++ b/modules/rtp_rtcp/source/rtp_format_video_generic.cc
@@ -43,7 +43,8 @@ RtpPacketizerGeneric::~RtpPacketizerGeneric() {}
 size_t RtpPacketizerGeneric::SetPayloadData(
     const uint8_t* payload_data,
     size_t payload_size,
-    const RTPFragmentationHeader* fragmentation) {
+    const RTPFragmentationHeader* fragmentation,
+    bool /*end_of_frame*/) {
   payload_data_ = payload_data;
   payload_size_ = payload_size;
 

--- a/modules/rtp_rtcp/source/rtp_format_video_generic.h
+++ b/modules/rtp_rtcp/source/rtp_format_video_generic.h
@@ -39,7 +39,8 @@ class RtpPacketizerGeneric : public RtpPacketizer {
   // Returns total number of packets to be generated.
   size_t SetPayloadData(const uint8_t* payload_data,
                         size_t payload_size,
-                        const RTPFragmentationHeader* fragmentation) override;
+                        const RTPFragmentationHeader* fragmentation,
+                        bool end_of_frame) override;
 
   // Get the next payload with generic payload header.
   // Write payload and set marker bit of the |packet|.

--- a/modules/rtp_rtcp/source/rtp_format_vp8.cc
+++ b/modules/rtp_rtcp/source/rtp_format_vp8.cc
@@ -175,7 +175,8 @@ RtpPacketizerVp8::~RtpPacketizerVp8() {}
 size_t RtpPacketizerVp8::SetPayloadData(
     const uint8_t* payload_data,
     size_t payload_size,
-    const RTPFragmentationHeader* /* fragmentation */) {
+    const RTPFragmentationHeader* /* fragmentation */,
+    bool /*end_of_frame*/) {
   payload_data_ = payload_data;
   payload_size_ = payload_size;
   if (GeneratePackets() < 0) {

--- a/modules/rtp_rtcp/source/rtp_format_vp8.h
+++ b/modules/rtp_rtcp/source/rtp_format_vp8.h
@@ -48,7 +48,8 @@ class RtpPacketizerVp8 : public RtpPacketizer {
 
   size_t SetPayloadData(const uint8_t* payload_data,
                         size_t payload_size,
-                        const RTPFragmentationHeader* fragmentation) override;
+                        const RTPFragmentationHeader* fragmentation,
+                        bool end_of_frame) override;
 
   // Get the next payload with VP8 payload header.
   // Write payload and set marker bit of the |packet|.

--- a/modules/rtp_rtcp/source/rtp_format_vp9.cc
+++ b/modules/rtp_rtcp/source/rtp_format_vp9.cc
@@ -478,7 +478,8 @@ std::string RtpPacketizerVp9::ToString() {
 size_t RtpPacketizerVp9::SetPayloadData(
     const uint8_t* payload,
     size_t payload_size,
-    const RTPFragmentationHeader* fragmentation) {
+    const RTPFragmentationHeader* fragmentation,
+    bool /*end_of_frame*/) {
   payload_ = payload;
   payload_size_ = payload_size;
   GeneratePackets();

--- a/modules/rtp_rtcp/source/rtp_format_vp9.h
+++ b/modules/rtp_rtcp/source/rtp_format_vp9.h
@@ -43,7 +43,8 @@ class RtpPacketizerVp9 : public RtpPacketizer {
   // The payload data must be one encoded VP9 layer frame.
   size_t SetPayloadData(const uint8_t* payload,
                         size_t payload_size,
-                        const RTPFragmentationHeader* fragmentation) override;
+                        const RTPFragmentationHeader* fragmentation,
+                        bool end_of_frame) override;
 
   // Gets the next payload with VP9 payload header.
   // Write payload and set marker bit of the |packet|.

--- a/modules/video_coding/codecs/h264/include/h264_globals.h
+++ b/modules/video_coding/codecs/h264/include/h264_globals.h
@@ -81,6 +81,13 @@ struct RTPVideoHeaderH264 {
   // depending along with Temporal ID (obtained from RTP header extn).
   // '0' if PictureID does not exist.
   uint16_t picture_id;
+  // For support slice-based transmission, mark end of a frame so that
+  // the H.264 packetizer will not set marker bit for the last fragment of
+  // current outgoing data if it does not contain last fragment of the frame;
+  // and will treat the first fragment of the frame as continuous playload, so
+  // that it will not create FU header or STAP-A header on first fragment if contains
+  // last fragment of the frame.
+  bool has_last_fragement;
 };
 
 }  // namespace webrtc

--- a/modules/video_coding/include/video_codec_interface.h
+++ b/modules/video_coding/include/video_codec_interface.h
@@ -71,6 +71,8 @@ struct CodecSpecificInfoH264 {
   H264PacketizationMode packetization_mode;
   uint8_t simulcast_idx;
   int16_t picture_id; // Required by temporal scalability
+  // Below is added to handle partial output from encoder.
+  bool last_fragment_in_frame;
 };
 
 union CodecSpecificInfoUnion {


### PR DESCRIPTION
webrtc stack change for slice-based encoding enabling. Now allow slice to be not started with NAL header, and also allow last NAL in the slice to be in-complete.