### PR TITLE
Enable GRPA bandwidth estimator. Need GRPA binary from Intel if you set owt_use_grpa to true.

### DIFF
--- a/modules/congestion_controller/BUILD.gn
+++ b/modules/congestion_controller/BUILD.gn
@@ -29,11 +29,18 @@ rtc_static_library("congestion_controller") {
     "receive_side_congestion_controller.cc",
     "send_side_congestion_controller.cc",
   ]
+  
+  include_dirs = [
+    "../gpra",
+  ]
 
   if (!build_with_chromium && is_clang) {
     # Suppress warnings from the Chromium Clang plugin (bugs.webrtc.org/163).
     suppressed_configs += [ "//build/config/clang:find_bad_constructs" ]
   }
+
+  #libs = ["gpra_lib.lib",
+  #]
 
   deps = [
     ":transport_feedback",
@@ -51,6 +58,7 @@ rtc_static_library("congestion_controller") {
     "../pacing",
     "../remote_bitrate_estimator",
     "../rtp_rtcp:rtp_rtcp_format",
+    #"../gpra",
     "goog_cc:delay_based_bwe",
     "goog_cc:estimators",
     "goog_cc:probe_controller",

--- a/modules/congestion_controller/BUILD.gn
+++ b/modules/congestion_controller/BUILD.gn
@@ -31,7 +31,7 @@ rtc_static_library("congestion_controller") {
   ]
   
   include_dirs = [
-    "../gpra",
+    "../gpra/include",
   ]
 
   if (!build_with_chromium && is_clang) {

--- a/modules/congestion_controller/BUILD.gn
+++ b/modules/congestion_controller/BUILD.gn
@@ -8,11 +8,13 @@
 
 import("../../webrtc.gni")
 
+defines = []
+
 config("bwe_test_logging") {
   if (rtc_enable_bwe_test_logging) {
-    defines = [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=1" ]
+    defines += [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=1" ]
   } else {
-    defines = [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0" ]
+    defines += [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0" ]
   }
 }
 
@@ -30,17 +32,18 @@ rtc_static_library("congestion_controller") {
     "send_side_congestion_controller.cc",
   ]
 
-  include_dirs = [
-    "../gpra/include",
-  ]
-
   if (!build_with_chromium && is_clang) {
     # Suppress warnings from the Chromium Clang plugin (bugs.webrtc.org/163).
     suppressed_configs += [ "//build/config/clang:find_bad_constructs" ]
   }
 
-  libs = ["gpra_lib.lib",
-  ]
+  if (owt_use_gpra) {
+     # use INTEL GoodPut Rate Adaptation BWE
+     include_dirs = [ owt_gpra_header_root ]
+     libs = [ "gpra_lib.lib" ]
+     lib_dirs = [ owt_gpra_lib_root ]
+     defines += [ "INTEL_GPRA" ]
+  }
 
   deps = [
     ":transport_feedback",
@@ -58,7 +61,6 @@ rtc_static_library("congestion_controller") {
     "../pacing",
     "../remote_bitrate_estimator",
     "../rtp_rtcp:rtp_rtcp_format",
-    "../gpra",
     "goog_cc:delay_based_bwe",
     "goog_cc:estimators",
     "goog_cc:probe_controller",

--- a/modules/congestion_controller/BUILD.gn
+++ b/modules/congestion_controller/BUILD.gn
@@ -29,7 +29,7 @@ rtc_static_library("congestion_controller") {
     "receive_side_congestion_controller.cc",
     "send_side_congestion_controller.cc",
   ]
-  
+
   include_dirs = [
     "../gpra/include",
   ]
@@ -39,8 +39,8 @@ rtc_static_library("congestion_controller") {
     suppressed_configs += [ "//build/config/clang:find_bad_constructs" ]
   }
 
-  #libs = ["gpra_lib.lib",
-  #]
+  libs = ["gpra_lib.lib",
+  ]
 
   deps = [
     ":transport_feedback",
@@ -58,7 +58,7 @@ rtc_static_library("congestion_controller") {
     "../pacing",
     "../remote_bitrate_estimator",
     "../rtp_rtcp:rtp_rtcp_format",
-    #"../gpra",
+    "../gpra",
     "goog_cc:delay_based_bwe",
     "goog_cc:estimators",
     "goog_cc:probe_controller",

--- a/modules/congestion_controller/BUILD.gn
+++ b/modules/congestion_controller/BUILD.gn
@@ -79,6 +79,10 @@ rtc_static_library("transport_feedback") {
     "transport_feedback_adapter.h",
   ]
 
+  if (owt_use_gpra) {
+     defines += [ "INTEL_GPRA" ]
+  }
+
   deps = [
     "../../modules:module_api",
     "../../rtc_base:checks",

--- a/modules/congestion_controller/include/send_side_congestion_controller.h
+++ b/modules/congestion_controller/include/send_side_congestion_controller.h
@@ -26,12 +26,8 @@
 #include "rtc_base/criticalsection.h"
 #include "rtc_base/networkroute.h"
 #include "rtc_base/race_checker.h"
-
 // To use INTEL GoodPut Rate Adaptation BWE
 #define INTEL_GPRA
-#ifdef INTEL_GPRA
-#include "NetworkPerfMeter.h"
-#endif
 
 namespace rtc {
 struct SentPacket;
@@ -46,6 +42,7 @@ class ProbeController;
 class RateLimiter;
 class RtcEventLog;
 class CongestionWindowPushbackController;
+class NetworkPerfMeter;
 
 class SendSideCongestionController
     : public SendSideCongestionControllerInterface {
@@ -170,7 +167,7 @@ class SendSideCongestionController
   rtc::CriticalSection bwe_lock_;
   int min_bitrate_bps_ RTC_GUARDED_BY(bwe_lock_);
 #ifdef INTEL_GPRA
-  std::unique_ptr<NetworkPerfMeter> delay_based_bwe_ GUARDED_BY(bwe_lock_);
+  std::unique_ptr<NetworkPerfMeter> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
 #else
   std::unique_ptr<DelayBasedBwe> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
 #endif

--- a/modules/congestion_controller/include/send_side_congestion_controller.h
+++ b/modules/congestion_controller/include/send_side_congestion_controller.h
@@ -26,8 +26,6 @@
 #include "rtc_base/criticalsection.h"
 #include "rtc_base/networkroute.h"
 #include "rtc_base/race_checker.h"
-// To use INTEL GoodPut Rate Adaptation BWE
-#define INTEL_GPRA
 
 namespace rtc {
 struct SentPacket;

--- a/modules/congestion_controller/include/send_side_congestion_controller.h
+++ b/modules/congestion_controller/include/send_side_congestion_controller.h
@@ -40,7 +40,7 @@ class ProbeController;
 class RateLimiter;
 class RtcEventLog;
 class CongestionWindowPushbackController;
-class NetworkPerfMeter;
+class GPRABwe;
 
 class SendSideCongestionController
     : public SendSideCongestionControllerInterface {
@@ -165,7 +165,7 @@ class SendSideCongestionController
   rtc::CriticalSection bwe_lock_;
   int min_bitrate_bps_ RTC_GUARDED_BY(bwe_lock_);
 #ifdef INTEL_GPRA
-  std::unique_ptr<NetworkPerfMeter> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
+  std::unique_ptr<GPRABwe> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
 #else
   std::unique_ptr<DelayBasedBwe> delay_based_bwe_ RTC_GUARDED_BY(bwe_lock_);
 #endif

--- a/modules/congestion_controller/send_side_congestion_controller.cc
+++ b/modules/congestion_controller/send_side_congestion_controller.cc
@@ -147,7 +147,12 @@ SendSideCongestionController::SendSideCongestionController(
       pause_pacer_(false),
       pacer_paused_(false),
       min_bitrate_bps_(congestion_controller::GetMinBitrateBps()),
+#ifdef INTEL_GPRA
+      delay_based_bwe_(new NetworkPerfMeter()) {
+      RTC_LOG(LS_ERROR) << "DebugP Use GPRA BWE!!!";
+#else
       delay_based_bwe_(new DelayBasedBwe(event_log_)),
+#endif
       in_cwnd_experiment_(CwndExperimentEnabled()),
       accepted_queue_ms_(kDefaultAcceptedQueueMs),
       was_in_alr_(false),
@@ -245,7 +250,11 @@ void SendSideCongestionController::OnNetworkRouteChanged(
     rtc::CritScope cs(&bwe_lock_);
     transport_overhead_bytes_per_packet_ = network_route.packet_overhead;
     min_bitrate_bps_ = min_bitrate_bps;
+#ifdef INETL_GPRA
+    delay_based_bwe_.reset(new NetworkPerfMeter());
+#else
     delay_based_bwe_.reset(new DelayBasedBwe(event_log_));
+#endif
     acknowledged_bitrate_estimator_.reset(new AcknowledgedBitrateEstimator());
     delay_based_bwe_->SetStartBitrate(bitrate_bps);
     delay_based_bwe_->SetMinBitrate(min_bitrate_bps);
@@ -420,6 +429,21 @@ void SendSideCongestionController::OnTransportFeedback(
   DelayBasedBwe::Result result;
   {
     rtc::CritScope cs(&bwe_lock_);
+#if 1 // Debug purpose
+    for (std::vector<PacketFeedback>::iterator it = feedback_vector.begin();
+         it != feedback_vector.end(); it++) {
+      RTC_LOG(LS_INFO) << "DebugP TxFB SeqNum:" << (*it).sequence_number << ", Size"
+                       << (*it).payload_size << ", Cap:"
+                       << (*it).creation_time_ms << ", Tx"
+                       << (*it).send_time_ms << ", Rx"
+                       << (*it).arrival_time_ms << ", Cap Delay:"
+                       << ((*it).send_time_ms - (*it).creation_time_ms)
+                       << ", N/W Delay:" << ((*it).arrival_time_ms - (*it).send_time_ms);
+    }
+#endif
+#ifdef INTEL_GPRA
+    delay_based_bwe_->SetCurrentOffsetMs(transport_feedback_adapter_.GetCurrentOffsetMs());
+#endif
     result = delay_based_bwe_->IncomingPacketFeedbackVector(
         feedback_vector, acknowledged_bitrate_estimator_->bitrate_bps(),
         clock_->TimeInMilliseconds());

--- a/modules/congestion_controller/send_side_congestion_controller.cc
+++ b/modules/congestion_controller/send_side_congestion_controller.cc
@@ -459,8 +459,9 @@ void SendSideCongestionController::OnTransportFeedback(
         feedback_vector, acknowledged_bitrate_estimator_->bitrate_bps(),
         clock_->TimeInMilliseconds());
 #else
-	//Jianlin: current IncomingPacketFeedbackVector accepts 3 params instead of 1. Consider consolidate to upstream.
-    result = delay_based_bwe_->IncomingPacketFeedbackVector(feedback_vector);
+    result = delay_based_bwe_->IncomingPacketFeedbackVector(
+        feedback_vector, *acknowledged_bitrate_estimator_->bitrate_bps(),
+        clock_->TimeInMilliseconds());
 #endif
   }
   if (result.updated) {

--- a/modules/congestion_controller/send_side_congestion_controller.cc
+++ b/modules/congestion_controller/send_side_congestion_controller.cc
@@ -34,7 +34,7 @@
 
 
 #ifdef INTEL_GPRA
-#include "NetworkPerfMeter.h"
+#include "gpra_bwe.h"
 #endif
 
 namespace webrtc {
@@ -153,7 +153,7 @@ SendSideCongestionController::SendSideCongestionController(
       pacer_paused_(false),
       min_bitrate_bps_(congestion_controller::GetMinBitrateBps()),
 #ifdef INTEL_GPRA
-      delay_based_bwe_(new NetworkPerfMeter()),
+      delay_based_bwe_(new GPRABwe()),
 #else
       delay_based_bwe_(new DelayBasedBwe(event_log_)),
 #endif
@@ -260,7 +260,7 @@ void SendSideCongestionController::OnNetworkRouteChanged(
     transport_overhead_bytes_per_packet_ = network_route.packet_overhead;
     min_bitrate_bps_ = min_bitrate_bps;
 #ifdef INTEL_GPRA
-    delay_based_bwe_.reset(new NetworkPerfMeter());
+    delay_based_bwe_.reset(new GPRABwe());
 #else
     delay_based_bwe_.reset(new DelayBasedBwe(event_log_));
 #endif

--- a/modules/congestion_controller/send_side_congestion_controller.cc
+++ b/modules/congestion_controller/send_side_congestion_controller.cc
@@ -438,7 +438,8 @@ void SendSideCongestionController::OnTransportFeedback(
   DelayBasedBwe::Result result;
   {
     rtc::CritScope cs(&bwe_lock_);
-#if 1 // Debug purpose
+#ifdef INTEL_GPRA
+#if 0 // Debug purpose
     for (std::vector<PacketFeedback>::iterator it = feedback_vector.begin();
          it != feedback_vector.end(); it++) {
       RTC_LOG(LS_INFO) << "DebugP TxFB SeqNum:" << (*it).sequence_number << ", Size"
@@ -450,17 +451,14 @@ void SendSideCongestionController::OnTransportFeedback(
                        << ", N/W Delay:" << ((*it).arrival_time_ms - (*it).send_time_ms);
     }
 #endif
-#ifdef INTEL_GPRA
     delay_based_bwe_->SetCurrentOffsetMs(transport_feedback_adapter_.GetCurrentOffsetMs());
-#endif
 
-#ifndef INTEL_GPRA
     result = delay_based_bwe_->IncomingPacketFeedbackVector(
-        feedback_vector, acknowledged_bitrate_estimator_->bitrate_bps(),
+        feedback_vector, *acknowledged_bitrate_estimator_->bitrate_bps(),
         clock_->TimeInMilliseconds());
 #else
     result = delay_based_bwe_->IncomingPacketFeedbackVector(
-        feedback_vector, *acknowledged_bitrate_estimator_->bitrate_bps(),
+        feedback_vector, acknowledged_bitrate_estimator_->bitrate_bps(),
         clock_->TimeInMilliseconds());
 #endif
   }

--- a/modules/congestion_controller/transport_feedback_adapter.cc
+++ b/modules/congestion_controller/transport_feedback_adapter.cc
@@ -89,6 +89,10 @@ void TransportFeedbackAdapter::SetNetworkIds(uint16_t local_id,
   remote_net_id_ = remote_id;
 }
 
+int64_t TransportFeedbackAdapter::GetCurrentOffsetMs() {
+  return current_offset_ms_;
+}
+
 std::vector<PacketFeedback> TransportFeedbackAdapter::GetPacketFeedbackVector(
     const rtcp::TransportFeedback& feedback) {
   int64_t timestamp_us = feedback.GetBaseTimeUs();

--- a/modules/congestion_controller/transport_feedback_adapter.cc
+++ b/modules/congestion_controller/transport_feedback_adapter.cc
@@ -89,9 +89,11 @@ void TransportFeedbackAdapter::SetNetworkIds(uint16_t local_id,
   remote_net_id_ = remote_id;
 }
 
+#ifdef INTEL_GPRA
 int64_t TransportFeedbackAdapter::GetCurrentOffsetMs() {
   return current_offset_ms_;
 }
+#endif
 
 std::vector<PacketFeedback> TransportFeedbackAdapter::GetPacketFeedbackVector(
     const rtcp::TransportFeedback& feedback) {

--- a/modules/congestion_controller/transport_feedback_adapter.h
+++ b/modules/congestion_controller/transport_feedback_adapter.h
@@ -55,6 +55,8 @@ class TransportFeedbackAdapter {
 
   size_t GetOutstandingBytes() const;
 
+  int64_t GetCurrentOffsetMs();
+
  private:
   std::vector<PacketFeedback> GetPacketFeedbackVector(
       const rtcp::TransportFeedback& feedback);

--- a/modules/congestion_controller/transport_feedback_adapter.h
+++ b/modules/congestion_controller/transport_feedback_adapter.h
@@ -55,7 +55,9 @@ class TransportFeedbackAdapter {
 
   size_t GetOutstandingBytes() const;
 
+#ifdef INTEL_GPRA
   int64_t GetCurrentOffsetMs();
+#endif
 
  private:
   std::vector<PacketFeedback> GetPacketFeedbackVector(


### PR DESCRIPTION
This patch series allows integration with GPRA BWE library from Intel (library and header supplied externally).
