### PR TITLE
Reenable HEVC on iOS.

### DIFF
--- a/api/video_codecs/video_codec.cc
+++ b/api/video_codecs/video_codec.cc
@@ -132,7 +132,6 @@ static const char* kPayloadNameH264 = "H264";
 #ifndef DISABLE_H265
 static const char* kPayloadNameH265 = "H265";
 #endif
-static const char* kPayloadNameI420 = "I420";
 static const char* kPayloadNameGeneric = "Generic";
 static const char* kPayloadNameMultiplex = "Multiplex";
 

--- a/call/rtp_payload_params.cc
+++ b/call/rtp_payload_params.cc
@@ -269,6 +269,9 @@ void RtpPayloadParams::SetGeneric(const CodecSpecificInfo* codec_specific_info,
       return;
     case VideoCodecType::kVideoCodecH264:
       // TODO(philipel): Implement H264 to new generic descriptor.
+#ifndef DISABLE_H265
+    case VideoCodecType::kVideoCodecH265:
+#endif
     case VideoCodecType::kVideoCodecMultiplex:
       return;
   }

--- a/modules/rtp_rtcp/source/rtp_format_h265.cc
+++ b/modules/rtp_rtcp/source/rtp_format_h265.cc
@@ -144,7 +144,7 @@ bool RtpPacketizerH265::GeneratePackets(
   // For HEVC we follow non-interleaved mode for the packetization,
   // and don't support single-nalu mode at present.
   for (size_t i = 0; i < input_fragments_.size();) {
-    size_t fragment_len = input_fragments_[i].length;
+    int fragment_len = input_fragments_[i].length;
     int single_packet_capacity = limits_.max_payload_len;
     if (input_fragments_.size() == 1)
       single_packet_capacity -= limits_.single_packet_reduction_len;

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1631,6 +1631,11 @@ if (is_ios || is_mac) {
         "objc/components/video_codec/RTCVideoEncoderFactoryH264.m",
         "objc/components/video_codec/RTCVideoEncoderH264.h",
         "objc/components/video_codec/RTCVideoEncoderH264.mm",
+        "objc/Framework/Headers/WebRTC/RTCVideoCodecH265.h",
+        "objc/components/video_codec/RTCVideoEncoderH265.mm",
+        "objc/components/video_codec/RTCVideoCodecH265.mm",
+        "objc/components/video_codec/RTCVideoDecoderH265.h",
+        "objc/components/video_codec/RTCVideoDecoderH265.mm",
       ]
 
       configs += [

--- a/sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecH265.h
+++ b/sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecH265.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+/* This file is borrowed from webrtc/sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecH264.h */
+
+#import <Foundation/Foundation.h>
+
+#import <WebRTC/RTCMacros.h>
+#import <WebRTC/RTCVideoCodecFactory.h>
+
+RTC_OBJC_EXPORT
+API_AVAILABLE(ios(11.0))
+@interface RTCCodecSpecificInfoH265 : NSObject <RTCCodecSpecificInfo>
+@end
+
+/** Encoder. */
+RTC_OBJC_EXPORT
+API_AVAILABLE(ios(11.0))
+@interface RTCVideoEncoderH265 : NSObject<RTCVideoEncoder>
+
+- (instancetype)initWithCodecInfo:(RTCVideoCodecInfo *)codecInfo;
+
+@end
+
+/** Decoder. */
+RTC_OBJC_EXPORT
+API_AVAILABLE(ios(11.0))
+@interface RTCVideoDecoderH265 : NSObject<RTCVideoDecoder>
+@end
+
+/** Encoder factory. */
+RTC_OBJC_EXPORT
+API_AVAILABLE(ios(11.0))
+@interface RTCVideoEncoderFactoryH265 : NSObject<RTCVideoEncoderFactory>
+@end
+
+/** Decoder factory. */
+RTC_OBJC_EXPORT
+API_AVAILABLE(ios(11.0))
+@interface RTCVideoDecoderFactoryH265 : NSObject<RTCVideoDecoderFactory>
+@end

--- a/sdk/objc/components/video_codec/RTCVideoCodecH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoCodecH265.mm
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+/* This file is borrowed from
+ * webrtc/sdk/objc/Framework/Classes/PeerConnection/RTCVideoCodecH265.mm */
+
+#import "WebRTC/RTCVideoCodecH265.h"
+
+#include <vector>
+
+#import "WebRTC/RTCVideoCodec.h"
+
+#include "rtc_base/time_utils.h"
+#include "system_wrappers/include/field_trial.h"
+
+static NSString* kH265CodecName = @"H265";
+// TODO(jianjunz): This is value is not correct.
+static NSString* kLevel31Main = @"4d001f";
+
+@implementation RTCCodecSpecificInfoH265
+@end
+
+// Encoder factory.
+@implementation RTCVideoEncoderFactoryH265
+
+- (NSArray<RTCVideoCodecInfo*>*)supportedCodecs {
+  NSMutableArray<RTCVideoCodecInfo*>* codecs = [NSMutableArray array];
+  NSString* codecName = kH265CodecName;
+
+  NSDictionary<NSString*, NSString*>* mainParams = @{
+    @"profile-level-id" : kLevel31Main,
+    @"level-asymmetry-allowed" : @"1",
+    @"packetization-mode" : @"1",
+  };
+  RTCVideoCodecInfo* constrainedBaselineInfo =
+      [[RTCVideoCodecInfo alloc] initWithName:codecName parameters:mainParams];
+  [codecs addObject:constrainedBaselineInfo];
+
+  return [codecs copy];
+}
+
+- (id<RTCVideoEncoder>)createEncoder:(RTCVideoCodecInfo*)info {
+  return [[RTCVideoEncoderH265 alloc] initWithCodecInfo:info];
+}
+
+@end
+
+// Decoder factory.
+@implementation RTCVideoDecoderFactoryH265
+
+- (id<RTCVideoDecoder>)createDecoder:(RTCVideoCodecInfo*)info {
+  return [[RTCVideoDecoderH265 alloc] init];
+}
+
+- (NSArray<RTCVideoCodecInfo*>*)supportedCodecs {
+  NSString* codecName = kH265CodecName;
+  return @[ [[RTCVideoCodecInfo alloc] initWithName:codecName parameters:nil] ];
+}
+
+@end

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -1,0 +1,277 @@
+/*
+ *  Copyright (c) 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ */
+
+#import "WebRTC/RTCVideoCodecH265.h"
+
+#import <VideoToolbox/VideoToolbox.h>
+
+#import "base/RTCVideoFrame.h"
+#import "base/RTCVideoFrameBuffer.h"
+#import "components/video_frame_buffer/RTCCVPixelBuffer.h"
+#import "helpers.h"
+#import "helpers/scoped_cftyperef.h"
+
+#if defined(WEBRTC_IOS)
+#import "helpers/UIDevice+RTCDevice.h"
+#endif
+
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#include "sdk/objc/components/video_codec/nalu_rewriter.h"
+
+// Struct that we pass to the decoder per frame to decode. We receive it again
+// in the decoder callback.
+struct RTCH265FrameDecodeParams {
+  RTCH265FrameDecodeParams(RTCVideoDecoderCallback cb, int64_t ts)
+      : callback(cb), timestamp(ts) {}
+  RTCVideoDecoderCallback callback;
+  int64_t timestamp;
+};
+
+// This is the callback function that VideoToolbox calls when decode is
+// complete.
+void h265DecompressionOutputCallback(void* decoder,
+                                     void* params,
+                                     OSStatus status,
+                                     VTDecodeInfoFlags infoFlags,
+                                     CVImageBufferRef imageBuffer,
+                                     CMTime timestamp,
+                                     CMTime duration) {
+  std::unique_ptr<RTCH265FrameDecodeParams> decodeParams(
+      reinterpret_cast<RTCH265FrameDecodeParams*>(params));
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
+    return;
+  }
+  // TODO(tkchin): Handle CVO properly.
+  RTCCVPixelBuffer* frameBuffer =
+      [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];
+  RTCVideoFrame* decodedFrame = [[RTCVideoFrame alloc]
+      initWithBuffer:frameBuffer
+            rotation:RTCVideoRotation_0
+         timeStampNs:CMTimeGetSeconds(timestamp) * rtc::kNumNanosecsPerSec];
+  decodedFrame.timeStamp = decodeParams->timestamp;
+  decodeParams->callback(decodedFrame);
+}
+
+// Decoder.
+@implementation RTCVideoDecoderH265 {
+  CMVideoFormatDescriptionRef _videoFormat;
+  VTDecompressionSessionRef _decompressionSession;
+  RTCVideoDecoderCallback _callback;
+  OSStatus _error;
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+
+  return self;
+}
+
+- (void)dealloc {
+  [self destroyDecompressionSession];
+  [self setVideoFormat:nullptr];
+}
+
+- (NSInteger)startDecodeWithNumberOfCores:(int)numberOfCores {
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (NSInteger)decode:(RTCEncodedImage*)inputImage
+          missingFrames:(BOOL)missingFrames
+      codecSpecificInfo:(__nullable id<RTCCodecSpecificInfo>)info
+           renderTimeMs:(int64_t)renderTimeMs {
+  RTC_DCHECK(inputImage.buffer);
+
+  if (_error != noErr) {
+    RTC_LOG(LS_WARNING) << "Last frame decode failed.";
+    _error = noErr;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  rtc::ScopedCFTypeRef<CMVideoFormatDescriptionRef> inputFormat =
+      rtc::ScopedCF(webrtc::CreateH265VideoFormatDescription(
+          (uint8_t*)inputImage.buffer.bytes, inputImage.buffer.length));
+  if (inputFormat) {
+    CMVideoDimensions dimensions =
+        CMVideoFormatDescriptionGetDimensions(inputFormat.get());
+    RTC_LOG(LS_INFO) << "Resolution: " << dimensions.width << " x "
+                     << dimensions.height;
+    // Check if the video format has changed, and reinitialize decoder if
+    // needed.
+    if (!CMFormatDescriptionEqual(inputFormat.get(), _videoFormat)) {
+      [self setVideoFormat:inputFormat.get()];
+      int resetDecompressionSessionError = [self resetDecompressionSession];
+      if (resetDecompressionSessionError != WEBRTC_VIDEO_CODEC_OK) {
+        return resetDecompressionSessionError;
+      }
+    }
+  }
+  if (!_videoFormat) {
+    // We received a frame but we don't have format information so we can't
+    // decode it.
+    // This can happen after backgrounding. We need to wait for the next
+    // sps/pps before we can resume so we request a keyframe by returning an
+    // error.
+    RTC_LOG(LS_WARNING) << "Missing video format. Frame with sps/pps required.";
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  CMSampleBufferRef sampleBuffer = nullptr;
+  if (!webrtc::H265AnnexBBufferToCMSampleBuffer(
+          (uint8_t*)inputImage.buffer.bytes, inputImage.buffer.length,
+          _videoFormat, &sampleBuffer)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  RTC_DCHECK(sampleBuffer);
+  VTDecodeFrameFlags decodeFlags =
+      kVTDecodeFrame_EnableAsynchronousDecompression;
+  std::unique_ptr<RTCH265FrameDecodeParams> frameDecodeParams;
+  frameDecodeParams.reset(
+      new RTCH265FrameDecodeParams(_callback, inputImage.timeStamp));
+  OSStatus status = VTDecompressionSessionDecodeFrame(
+      _decompressionSession, sampleBuffer, decodeFlags,
+      frameDecodeParams.release(), nullptr);
+#if defined(WEBRTC_IOS)
+  // Re-initialize the decoder if we have an invalid session while the app is
+  // active and retry the decode request.
+  if (status == kVTInvalidSessionErr &&
+      [self resetDecompressionSession] == WEBRTC_VIDEO_CODEC_OK) {
+    frameDecodeParams.reset(
+        new RTCH265FrameDecodeParams(_callback, inputImage.timeStamp));
+    status = VTDecompressionSessionDecodeFrame(
+        _decompressionSession, sampleBuffer, decodeFlags,
+        frameDecodeParams.release(), nullptr);
+  }
+#endif
+  CFRelease(sampleBuffer);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to decode frame with code: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)setCallback:(RTCVideoDecoderCallback)callback {
+  _callback = callback;
+}
+
+- (NSInteger)releaseDecoder {
+  // Need to invalidate the session so that callbacks no longer occur and it
+  // is safe to null out the callback.
+  [self destroyDecompressionSession];
+  [self setVideoFormat:nullptr];
+  _callback = nullptr;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+#pragma mark - Private
+
+- (int)resetDecompressionSession {
+  [self destroyDecompressionSession];
+
+  // Need to wait for the first SPS to initialize decoder.
+  if (!_videoFormat) {
+    return WEBRTC_VIDEO_CODEC_OK;
+  }
+
+  // Set keys for OpenGL and IOSurface compatibilty, which makes the encoder
+  // create pixel buffers with GPU backed memory. The intent here is to pass
+  // the pixel buffers directly so we avoid a texture upload later during
+  // rendering. This currently is moot because we are converting back to an
+  // I420 frame after decode, but eventually we will be able to plumb
+  // CVPixelBuffers directly to the renderer.
+  // TODO(tkchin): Maybe only set OpenGL/IOSurface keys if we know that that
+  // we can pass CVPixelBuffers as native handles in decoder output.
+  static size_t const attributesSize = 3;
+  CFTypeRef keys[attributesSize] = {
+#if defined(WEBRTC_IOS)
+    kCVPixelBufferOpenGLESCompatibilityKey,
+#elif defined(WEBRTC_MAC)
+    kCVPixelBufferOpenGLCompatibilityKey,
+#endif
+    kCVPixelBufferIOSurfacePropertiesKey,
+    kCVPixelBufferPixelFormatTypeKey
+  };
+  CFDictionaryRef ioSurfaceValue = CreateCFTypeDictionary(nullptr, nullptr, 0);
+  int64_t nv12type = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+  CFNumberRef pixelFormat =
+      CFNumberCreate(nullptr, kCFNumberLongType, &nv12type);
+  CFTypeRef values[attributesSize] = {kCFBooleanTrue, ioSurfaceValue,
+                                      pixelFormat};
+  CFDictionaryRef attributes =
+      CreateCFTypeDictionary(keys, values, attributesSize);
+  if (ioSurfaceValue) {
+    CFRelease(ioSurfaceValue);
+    ioSurfaceValue = nullptr;
+  }
+  if (pixelFormat) {
+    CFRelease(pixelFormat);
+    pixelFormat = nullptr;
+  }
+  VTDecompressionOutputCallbackRecord record = {
+      h265DecompressionOutputCallback,
+      nullptr,
+  };
+  OSStatus status =
+      VTDecompressionSessionCreate(nullptr, _videoFormat, nullptr, attributes,
+                                   &record, &_decompressionSession);
+  CFRelease(attributes);
+  if (status != noErr) {
+    [self destroyDecompressionSession];
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  [self configureDecompressionSession];
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)configureDecompressionSession {
+  RTC_DCHECK(_decompressionSession);
+#if defined(WEBRTC_IOS)
+  // VTSessionSetProperty(_decompressionSession,
+  // kVTDecompressionPropertyKey_RealTime, kCFBooleanTrue);
+#endif
+}
+
+- (void)destroyDecompressionSession {
+  if (_decompressionSession) {
+#if defined(WEBRTC_IOS)
+    if ([UIDevice isIOS11OrLater]) {
+      VTDecompressionSessionWaitForAsynchronousFrames(_decompressionSession);
+    }
+#endif
+    VTDecompressionSessionInvalidate(_decompressionSession);
+    CFRelease(_decompressionSession);
+    _decompressionSession = nullptr;
+  }
+}
+
+- (void)setVideoFormat:(CMVideoFormatDescriptionRef)videoFormat {
+  if (_videoFormat == videoFormat) {
+    return;
+  }
+  if (_videoFormat) {
+    CFRelease(_videoFormat);
+  }
+  _videoFormat = videoFormat;
+  if (_videoFormat) {
+    CFRetain(_videoFormat);
+  }
+}
+
+- (NSString*)implementationName {
+  return @"VideoToolbox";
+}
+
+@end

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
@@ -1,0 +1,604 @@
+/*
+ *  Copyright (c) 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ */
+
+#import "WebRTC/RTCVideoCodecH265.h"
+
+#import <VideoToolbox/VideoToolbox.h>
+#include <vector>
+
+#if defined(WEBRTC_IOS)
+#import "helpers/UIDevice+RTCDevice.h"
+#endif
+#import "WebRTC/RTCVideoCodec.h"
+#import "WebRTC/RTCVideoFrame.h"
+#import "WebRTC/RTCVideoFrameBuffer.h"
+#include "common_video/h264/profile_level_id.h"
+#include "common_video/include/bitrate_adjuster.h"
+#include "libyuv/convert_from.h"
+#include "modules/include/module_common_types.h"
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/buffer.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#import "sdk/objc/Framework/Classes/PeerConnection/RTCVideoCodec+Private.h"
+#import "helpers.h"
+#include "sdk/objc/Framework/Classes/VideoToolbox/nalu_rewriter.h"
+#include "system_wrappers/include/clock.h"
+
+@interface RTCVideoEncoderH265 ()
+
+- (void)frameWasEncoded:(OSStatus)status
+                  flags:(VTEncodeInfoFlags)infoFlags
+           sampleBuffer:(CMSampleBufferRef)sampleBuffer
+                  width:(int32_t)width
+                 height:(int32_t)height
+           renderTimeMs:(int64_t)renderTimeMs
+              timestamp:(uint32_t)timestamp
+               rotation:(RTCVideoRotation)rotation;
+
+@end
+
+namespace {  // anonymous namespace
+
+// The ratio between kVTCompressionPropertyKey_DataRateLimits and
+// kVTCompressionPropertyKey_AverageBitRate. The data rate limit is set higher
+// than the average bit rate to avoid undershooting the target.
+const float kLimitToAverageBitRateFactor = 1.5f;
+// These thresholds deviate from the default h265 QP thresholds, as they
+// have been found to work better on devices that support VideoToolbox
+const int kLowh265QpThreshold = 28;
+const int kHighh265QpThreshold = 39;
+
+// Struct that we pass to the encoder per frame to encode. We receive it again
+// in the encoder callback.
+struct API_AVAILABLE(ios(11.0)) RTCFrameEncodeParams {
+  RTCFrameEncodeParams(RTCVideoEncoderH265* e,
+                       int32_t w,
+                       int32_t h,
+                       int64_t rtms,
+                       uint32_t ts,
+                       RTCVideoRotation r)
+      : encoder(e),
+        width(w),
+        height(h),
+        render_time_ms(rtms),
+        timestamp(ts),
+        rotation(r) {}
+
+  RTCVideoEncoderH265* encoder;
+  int32_t width;
+  int32_t height;
+  int64_t render_time_ms;
+  uint32_t timestamp;
+  RTCVideoRotation rotation;
+};
+
+// We receive I420Frames as input, but we need to feed CVPixelBuffers into the
+// encoder. This performs the copy and format conversion.
+// TODO(tkchin): See if encoder will accept i420 frames and compare performance.
+bool CopyVideoFrameToPixelBuffer(id<RTCI420Buffer> frameBuffer,
+                                 CVPixelBufferRef pixelBuffer) {
+  RTC_DCHECK(pixelBuffer);
+  RTC_DCHECK_EQ(CVPixelBufferGetPixelFormatType(pixelBuffer),
+                kCVPixelFormatType_420YpCbCr8BiPlanarFullRange);
+  RTC_DCHECK_EQ(CVPixelBufferGetHeightOfPlane(pixelBuffer, 0),
+                frameBuffer.height);
+  RTC_DCHECK_EQ(CVPixelBufferGetWidthOfPlane(pixelBuffer, 0),
+                frameBuffer.width);
+
+  CVReturn cvRet = CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+  if (cvRet != kCVReturnSuccess) {
+    RTC_LOG(LS_ERROR) << "Failed to lock base address: " << cvRet;
+    return false;
+  }
+
+  uint8_t* dstY = reinterpret_cast<uint8_t*>(
+      CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+  int dstStrideY = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0);
+  uint8_t* dstUV = reinterpret_cast<uint8_t*>(
+      CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+  int dstStrideUV = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1);
+  // Convert I420 to NV12.
+  int ret = libyuv::I420ToNV12(
+      frameBuffer.dataY, frameBuffer.strideY, frameBuffer.dataU,
+      frameBuffer.strideU, frameBuffer.dataV, frameBuffer.strideV, dstY,
+      dstStrideY, dstUV, dstStrideUV, frameBuffer.width, frameBuffer.height);
+  CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+  if (ret) {
+    RTC_LOG(LS_ERROR) << "Error converting I420 VideoFrame to NV12 :" << ret;
+    return false;
+  }
+  return true;
+}
+
+CVPixelBufferRef CreatePixelBuffer(CVPixelBufferPoolRef pixel_buffer_pool) {
+  if (!pixel_buffer_pool) {
+    RTC_LOG(LS_ERROR) << "Failed to get pixel buffer pool.";
+    return nullptr;
+  }
+  CVPixelBufferRef pixel_buffer;
+  CVReturn ret = CVPixelBufferPoolCreatePixelBuffer(nullptr, pixel_buffer_pool,
+                                                    &pixel_buffer);
+  if (ret != kCVReturnSuccess) {
+    RTC_LOG(LS_ERROR) << "Failed to create pixel buffer: " << ret;
+    // We probably want to drop frames here, since failure probably means
+    // that the pool is empty.
+    return nullptr;
+  }
+  return pixel_buffer;
+}
+
+// This is the callback function that VideoToolbox calls when encode is
+// complete. From inspection this happens on its own queue.
+void compressionOutputCallback(void* encoder,
+                               void* params,
+                               OSStatus status,
+                               VTEncodeInfoFlags infoFlags,
+                               CMSampleBufferRef sampleBuffer)
+    API_AVAILABLE(ios(11.0)) {
+  RTC_CHECK(params);
+  std::unique_ptr<RTCFrameEncodeParams> encodeParams(
+      reinterpret_cast<RTCFrameEncodeParams*>(params));
+  RTC_CHECK(encodeParams->encoder);
+  [encodeParams->encoder frameWasEncoded:status
+                                   flags:infoFlags
+                            sampleBuffer:sampleBuffer
+                                   width:encodeParams->width
+                                  height:encodeParams->height
+                            renderTimeMs:encodeParams->render_time_ms
+                               timestamp:encodeParams->timestamp
+                                rotation:encodeParams->rotation];
+}
+}  // namespace
+
+@implementation RTCVideoEncoderH265 {
+  RTCVideoCodecInfo* _codecInfo;
+  std::unique_ptr<webrtc::BitrateAdjuster> _bitrateAdjuster;
+  uint32_t _targetBitrateBps;
+  uint32_t _encoderBitrateBps;
+  CFStringRef _profile;
+  RTCVideoEncoderCallback _callback;
+  int32_t _width;
+  int32_t _height;
+  VTCompressionSessionRef _compressionSession;
+  RTCVideoCodecMode _mode;
+  int framesLeft;
+
+  std::vector<uint8_t> _nv12ScaleBuffer;
+}
+
+// .5 is set as a mininum to prevent overcompensating for large temporary
+// overshoots. We don't want to degrade video quality too badly.
+// .95 is set to prevent oscillations. When a lower bitrate is set on the
+// encoder than previously set, its output seems to have a brief period of
+// drastically reduced bitrate, so we want to avoid that. In steady state
+// conditions, 0.95 seems to give us better overall bitrate over long periods
+// of time.
+- (instancetype)initWithCodecInfo:(RTCVideoCodecInfo*)codecInfo {
+  if (self = [super init]) {
+    _codecInfo = codecInfo;
+    _bitrateAdjuster.reset(new webrtc::BitrateAdjuster(.5, .95));
+    RTC_CHECK([codecInfo.name isEqualToString:@"H265"]);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self destroyCompressionSession];
+}
+
+- (NSInteger)startEncodeWithSettings:(RTCVideoEncoderSettings*)settings
+                       numberOfCores:(int)numberOfCores {
+  RTC_DCHECK(settings);
+  RTC_DCHECK([settings.name isEqualToString:@"H265"]);
+
+  _width = settings.width;
+  _height = settings.height;
+  _mode = settings.mode;
+
+  // We can only set average bitrate on the HW encoder.
+  _targetBitrateBps = settings.startBitrate;
+  _bitrateAdjuster->SetTargetBitrateBps(_targetBitrateBps);
+
+  // TODO(tkchin): Try setting payload size via
+  // kVTCompressionPropertyKey_Maxh265SliceBytes.
+
+  return [self resetCompressionSession];
+}
+
+- (NSInteger)encode:(RTCVideoFrame*)frame
+    codecSpecificInfo:(id<RTCCodecSpecificInfo>)codecSpecificInfo
+           frameTypes:(NSArray<NSNumber*>*)frameTypes {
+  RTC_DCHECK_EQ(frame.width, _width);
+  RTC_DCHECK_EQ(frame.height, _height);
+  if (!_callback || !_compressionSession) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  BOOL isKeyframeRequired = NO;
+
+  // Get a pixel buffer from the pool and copy frame data over.
+  CVPixelBufferPoolRef pixelBufferPool =
+      VTCompressionSessionGetPixelBufferPool(_compressionSession);
+
+#if defined(WEBRTC_IOS)
+  if (!pixelBufferPool) {
+    // Kind of a hack. On backgrounding, the compression session seems to get
+    // invalidated, which causes this pool call to fail when the application
+    // is foregrounded and frames are being sent for encoding again.
+    // Resetting the session when this happens fixes the issue.
+    // In addition we request a keyframe so video can recover quickly.
+    [self resetCompressionSession];
+    pixelBufferPool =
+        VTCompressionSessionGetPixelBufferPool(_compressionSession);
+    isKeyframeRequired = YES;
+    RTC_LOG(LS_INFO) << "Resetting compression session due to invalid pool.";
+  }
+#endif
+
+  CVPixelBufferRef pixelBuffer = nullptr;
+  if ([frame.buffer isKindOfClass:[RTCCVPixelBuffer class]]) {
+    // Native frame buffer
+    RTCCVPixelBuffer* rtcPixelBuffer = (RTCCVPixelBuffer*)frame.buffer;
+    if (![rtcPixelBuffer requiresCropping]) {
+      // This pixel buffer might have a higher resolution than what the
+      // compression session is configured to. The compression session can
+      // handle that and will output encoded frames in the configured
+      // resolution regardless of the input pixel buffer resolution.
+      pixelBuffer = rtcPixelBuffer.pixelBuffer;
+      CVBufferRetain(pixelBuffer);
+    } else {
+      // Cropping required, we need to crop and scale to a new pixel buffer.
+      pixelBuffer = CreatePixelBuffer(pixelBufferPool);
+      if (!pixelBuffer) {
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+      int dstWidth = CVPixelBufferGetWidth(pixelBuffer);
+      int dstHeight = CVPixelBufferGetHeight(pixelBuffer);
+      if ([rtcPixelBuffer requiresScalingToWidth:dstWidth height:dstHeight]) {
+        int size =
+            [rtcPixelBuffer bufferSizeForCroppingAndScalingToWidth:dstWidth
+                                                            height:dstHeight];
+        _nv12ScaleBuffer.resize(size);
+      } else {
+        _nv12ScaleBuffer.clear();
+      }
+      _nv12ScaleBuffer.shrink_to_fit();
+      if (![rtcPixelBuffer cropAndScaleTo:pixelBuffer
+                           withTempBuffer:_nv12ScaleBuffer.data()]) {
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+    }
+  }
+
+  if (!pixelBuffer) {
+    // We did not have a native frame buffer
+    pixelBuffer = CreatePixelBuffer(pixelBufferPool);
+    if (!pixelBuffer) {
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    RTC_DCHECK(pixelBuffer);
+    if (!CopyVideoFrameToPixelBuffer([frame.buffer toI420], pixelBuffer)) {
+      RTC_LOG(LS_ERROR) << "Failed to copy frame data.";
+      CVBufferRelease(pixelBuffer);
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+  }
+
+  // Check if we need a keyframe.
+  if (!isKeyframeRequired && frameTypes) {
+    for (NSNumber* frameType in frameTypes) {
+      if ((RTCFrameType)frameType.intValue == RTCFrameTypeVideoFrameKey) {
+        isKeyframeRequired = YES;
+        break;
+      }
+    }
+  }
+
+  CMTime presentationTimeStamp =
+      CMTimeMake(frame.timeStampNs / rtc::kNumNanosecsPerMillisec, 1000);
+  CFDictionaryRef frameProperties = nullptr;
+  if (isKeyframeRequired) {
+    CFTypeRef keys[] = {kVTEncodeFrameOptionKey_ForceKeyFrame};
+    CFTypeRef values[] = {kCFBooleanTrue};
+    frameProperties = CreateCFTypeDictionary(keys, values, 1);
+  }
+
+  std::unique_ptr<RTCFrameEncodeParams> encodeParams;
+  encodeParams.reset(new RTCFrameEncodeParams(
+      self, _width, _height, frame.timeStampNs / rtc::kNumNanosecsPerMillisec,
+      frame.timeStamp, frame.rotation));
+
+  // Update the bitrate if needed.
+  [self setBitrateBps:_bitrateAdjuster->GetAdjustedBitrateBps()];
+
+  OSStatus status = VTCompressionSessionEncodeFrame(
+      _compressionSession, pixelBuffer, presentationTimeStamp, kCMTimeInvalid,
+      frameProperties, encodeParams.release(), nullptr);
+  if (frameProperties) {
+    CFRelease(frameProperties);
+  }
+  if (pixelBuffer) {
+    CVBufferRelease(pixelBuffer);
+  }
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to encode frame with code: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)setCallback:(RTCVideoEncoderCallback)callback {
+  _callback = callback;
+}
+
+- (int)setBitrate:(uint32_t)bitrateKbit framerate:(uint32_t)framerate {
+  _targetBitrateBps = 1000 * bitrateKbit;
+  _bitrateAdjuster->SetTargetBitrateBps(_targetBitrateBps);
+  [self setBitrateBps:_bitrateAdjuster->GetAdjustedBitrateBps()];
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+#pragma mark - Private
+
+- (NSInteger)releaseEncoder {
+  // Need to destroy so that the session is invalidated and won't use the
+  // callback anymore. Do not remove callback until the session is invalidated
+  // since async encoder callbacks can occur until invalidation.
+  [self destroyCompressionSession];
+  _callback = nullptr;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (int)resetCompressionSession {
+  [self destroyCompressionSession];
+
+  // Set source image buffer attributes. These attributes will be present on
+  // buffers retrieved from the encoder's pixel buffer pool.
+  const size_t attributesSize = 3;
+  CFTypeRef keys[attributesSize] = {
+#if defined(WEBRTC_IOS)
+    kCVPixelBufferOpenGLESCompatibilityKey,
+#elif defined(WEBRTC_MAC)
+    kCVPixelBufferOpenGLCompatibilityKey,
+#endif
+    kCVPixelBufferIOSurfacePropertiesKey,
+    kCVPixelBufferPixelFormatTypeKey
+  };
+  CFDictionaryRef ioSurfaceValue = CreateCFTypeDictionary(nullptr, nullptr, 0);
+  int64_t nv12type = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+  CFNumberRef pixelFormat =
+      CFNumberCreate(nullptr, kCFNumberLongType, &nv12type);
+  CFTypeRef values[attributesSize] = {kCFBooleanTrue, ioSurfaceValue,
+                                      pixelFormat};
+  CFDictionaryRef sourceAttributes =
+      CreateCFTypeDictionary(keys, values, attributesSize);
+  if (ioSurfaceValue) {
+    CFRelease(ioSurfaceValue);
+    ioSurfaceValue = nullptr;
+  }
+  if (pixelFormat) {
+    CFRelease(pixelFormat);
+    pixelFormat = nullptr;
+  }
+  CFMutableDictionaryRef encoder_specs = nullptr;
+#if defined(WEBRTC_MAC) && !defined(WEBRTC_IOS)
+  // Currently hw accl is supported above 360p on mac, below 360p
+  // the compression session will be created with hw accl disabled.
+  encoder_specs =
+      CFDictionaryCreateMutable(nullptr, 1, &kCFTypeDictionaryKeyCallBacks,
+                                &kCFTypeDictionaryValueCallBacks);
+  CFDictionarySetValue(
+      encoder_specs,
+      kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder,
+      kCFBooleanTrue);
+#endif
+  OSStatus status = VTCompressionSessionCreate(
+      nullptr,  // use default allocator
+      _width, _height, kCMVideoCodecType_HEVC,
+      encoder_specs,  // use hardware accelerated encoder if available
+      sourceAttributes,
+      nullptr,  // use default compressed data allocator
+      compressionOutputCallback, nullptr, &_compressionSession);
+  if (sourceAttributes) {
+    CFRelease(sourceAttributes);
+    sourceAttributes = nullptr;
+  }
+  if (encoder_specs) {
+    CFRelease(encoder_specs);
+    encoder_specs = nullptr;
+  }
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to create compression session: " << status;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+#if defined(WEBRTC_MAC) && !defined(WEBRTC_IOS)
+  CFBooleanRef hwaccl_enabled = nullptr;
+  status = VTSessionCopyProperty(
+      _compressionSession,
+      kVTCompressionPropertyKey_UsingHardwareAcceleratedVideoEncoder, nullptr,
+      &hwaccl_enabled);
+  if (status == noErr && (CFBooleanGetValue(hwaccl_enabled))) {
+    RTC_LOG(LS_INFO) << "Compression session created with hw accl enabled";
+  } else {
+    RTC_LOG(LS_INFO) << "Compression session created with hw accl disabled";
+  }
+#endif
+  [self configureCompressionSession];
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+- (void)configureCompressionSession {
+  RTC_DCHECK(_compressionSession);
+  SetVTSessionProperty(_compressionSession, kVTCompressionPropertyKey_RealTime,
+                       false);
+  // SetVTSessionProperty(_compressionSession,
+  // kVTCompressionPropertyKey_ProfileLevel, _profile);
+  SetVTSessionProperty(_compressionSession,
+                       kVTCompressionPropertyKey_AllowFrameReordering, false);
+  [self setEncoderBitrateBps:_targetBitrateBps];
+  // TODO(tkchin): Look at entropy mode and colorspace matrices.
+  // TODO(tkchin): Investigate to see if there's any way to make this work.
+  // May need it to interop with Android. Currently this call just fails.
+  // On inspecting encoder output on iOS8, this value is set to 6.
+  // internal::SetVTSessionProperty(compression_session_,
+  //     kVTCompressionPropertyKey_MaxFrameDelayCount,
+  //     1);
+
+  // Set a relatively large value for keyframe emission (7200 frames or 4
+  // minutes).
+  SetVTSessionProperty(_compressionSession,
+                       kVTCompressionPropertyKey_MaxKeyFrameInterval, 7200);
+  SetVTSessionProperty(_compressionSession,
+                       kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration,
+                       240);
+  OSStatus status =
+      VTCompressionSessionPrepareToEncodeFrames(_compressionSession);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Compression session failed to prepare encode frames.";
+  }
+}
+
+- (void)destroyCompressionSession {
+  if (_compressionSession) {
+    VTCompressionSessionInvalidate(_compressionSession);
+    CFRelease(_compressionSession);
+    _compressionSession = nullptr;
+  }
+}
+
+- (NSString*)implementationName {
+  return @"VideoToolbox";
+}
+
+- (void)setBitrateBps:(uint32_t)bitrateBps {
+  if (_encoderBitrateBps != bitrateBps) {
+    [self setEncoderBitrateBps:bitrateBps];
+  }
+}
+
+- (void)setEncoderBitrateBps:(uint32_t)bitrateBps {
+  if (_compressionSession) {
+    SetVTSessionProperty(_compressionSession,
+                         kVTCompressionPropertyKey_AverageBitRate, bitrateBps);
+
+    // TODO(tkchin): Add a helper method to set array value.
+    int64_t dataLimitBytesPerSecondValue =
+        static_cast<int64_t>(bitrateBps * kLimitToAverageBitRateFactor / 8);
+    CFNumberRef bytesPerSecond =
+        CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type,
+                       &dataLimitBytesPerSecondValue);
+    int64_t oneSecondValue = 1;
+    CFNumberRef oneSecond = CFNumberCreate(
+        kCFAllocatorDefault, kCFNumberSInt64Type, &oneSecondValue);
+    const void* nums[2] = {bytesPerSecond, oneSecond};
+    CFArrayRef dataRateLimits =
+        CFArrayCreate(nullptr, nums, 2, &kCFTypeArrayCallBacks);
+    OSStatus status = VTSessionSetProperty(
+        _compressionSession, kVTCompressionPropertyKey_DataRateLimits,
+        dataRateLimits);
+    if (bytesPerSecond) {
+      CFRelease(bytesPerSecond);
+    }
+    if (oneSecond) {
+      CFRelease(oneSecond);
+    }
+    if (dataRateLimits) {
+      CFRelease(dataRateLimits);
+    }
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to set data rate limit";
+    }
+
+    _encoderBitrateBps = bitrateBps;
+  }
+}
+
+- (void)frameWasEncoded:(OSStatus)status
+                  flags:(VTEncodeInfoFlags)infoFlags
+           sampleBuffer:(CMSampleBufferRef)sampleBuffer
+                  width:(int32_t)width
+                 height:(int32_t)height
+           renderTimeMs:(int64_t)renderTimeMs
+              timestamp:(uint32_t)timestamp
+               rotation:(RTCVideoRotation)rotation {
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "h265 encode failed.";
+    return;
+  }
+  if (infoFlags & kVTEncodeInfo_FrameDropped) {
+    RTC_LOG(LS_INFO) << "h265 encoder dropped a frame.";
+    return;
+  }
+
+  BOOL isKeyframe = NO;
+  CFArrayRef attachments =
+      CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, 0);
+  if (attachments != nullptr && CFArrayGetCount(attachments)) {
+    CFDictionaryRef attachment =
+        static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(attachments, 0));
+    isKeyframe =
+        !CFDictionaryContainsKey(attachment, kCMSampleAttachmentKey_NotSync);
+  }
+
+  if (isKeyframe) {
+    RTC_LOG(LS_INFO) << "Generated keyframe";
+  }
+
+  // Convert the sample buffer into a buffer suitable for RTP packetization.
+  // TODO(tkchin): Allocate buffers through a pool.
+  std::unique_ptr<rtc::Buffer> buffer(new rtc::Buffer());
+  RTCRtpFragmentationHeader* header;
+  {
+    std::unique_ptr<webrtc::RTPFragmentationHeader> header_cpp;
+    bool result = H265CMSampleBufferToAnnexBBuffer(sampleBuffer, isKeyframe,
+                                                   buffer.get(), &header_cpp);
+    header = [[RTCRtpFragmentationHeader alloc]
+        initWithNativeFragmentationHeader:header_cpp.get()];
+    if (!result) {
+      RTC_LOG(LS_ERROR) << "Failed to convert sample buffer.";
+      return;
+    }
+  }
+
+  RTCEncodedImage* frame = [[RTCEncodedImage alloc] init];
+  frame.buffer = [NSData dataWithBytesNoCopy:buffer->data()
+                                      length:buffer->size()
+                                freeWhenDone:NO];
+  frame.encodedWidth = width;
+  frame.encodedHeight = height;
+  frame.completeFrame = YES;
+  frame.frameType =
+      isKeyframe ? RTCFrameTypeVideoFrameKey : RTCFrameTypeVideoFrameDelta;
+  frame.captureTimeMs = renderTimeMs;
+  frame.timeStamp = timestamp;
+  frame.rotation = rotation;
+  frame.contentType = (_mode == RTCVideoCodecModeScreensharing)
+                          ? RTCVideoContentTypeScreenshare
+                          : RTCVideoContentTypeUnspecified;
+  frame.flags = webrtc::VideoSendTiming::kInvalid;
+
+  // TODO: QP is ignored because of there is no H.265 bitstream parser.
+
+  BOOL res = _callback(frame, [[RTCCodecSpecificInfoH265 alloc] init], header);
+  if (!res) {
+    RTC_LOG(LS_ERROR) << "Encode callback failed.";
+    return;
+  }
+  _bitrateAdjuster->Update(frame.buffer.length);
+}
+
+- (RTCVideoEncoderQpThresholds*)scalingSettings {
+  return [[RTCVideoEncoderQpThresholds alloc]
+      initWithThresholdsLow:kLowh265QpThreshold
+                       high:kHighh265QpThreshold];
+}
+
+@end

--- a/sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -248,6 +248,233 @@ bool H264AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
   return true;
 }
 
+bool H265CMSampleBufferToAnnexBBuffer(
+    CMSampleBufferRef hvcc_sample_buffer,
+    bool is_keyframe,
+    rtc::Buffer* annexb_buffer,
+    std::unique_ptr<RTPFragmentationHeader> *out_header) {
+  RTC_DCHECK(hvcc_sample_buffer);
+  RTC_DCHECK(out_header);
+  out_header->reset(nullptr);
+
+  // Get format description from the sample buffer.
+  CMVideoFormatDescriptionRef description =
+      CMSampleBufferGetFormatDescription(hvcc_sample_buffer);
+  if (description == nullptr) {
+    RTC_LOG(LS_ERROR) << "Failed to get sample buffer's description.";
+    return false;
+  }
+
+  // Get parameter set information.
+  int nalu_header_size = 0;
+  size_t param_set_count = 0;
+  OSStatus status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+      description, 0, nullptr, nullptr, &param_set_count, &nalu_header_size);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get parameter set.";
+    return false;
+  }
+  RTC_CHECK_EQ(nalu_header_size, kAvccHeaderByteSize);
+  RTC_DCHECK_EQ(param_set_count, 3);
+
+  // Truncate any previous data in the buffer without changing its capacity.
+  annexb_buffer->SetSize(0);
+
+  size_t nalu_offset = 0;
+  std::vector<size_t> frag_offsets;
+  std::vector<size_t> frag_lengths;
+
+  // Place all parameter sets at the front of buffer.
+  if (is_keyframe) {
+    size_t param_set_size = 0;
+    const uint8_t* param_set = nullptr;
+    for (size_t i = 0; i < param_set_count; ++i) {
+      status = CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+          description, i, &param_set, &param_set_size, nullptr, nullptr);
+      if (status != noErr) {
+        RTC_LOG(LS_ERROR) << "Failed to get parameter set.";
+        return false;
+      }
+      // Update buffer.
+      annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+      annexb_buffer->AppendData(reinterpret_cast<const char*>(param_set),
+                                param_set_size);
+      // Update fragmentation.
+      frag_offsets.push_back(nalu_offset + sizeof(kAnnexBHeaderBytes));
+      frag_lengths.push_back(param_set_size);
+      nalu_offset += sizeof(kAnnexBHeaderBytes) + param_set_size;
+    }
+  }
+
+  // Get block buffer from the sample buffer.
+  CMBlockBufferRef block_buffer =
+      CMSampleBufferGetDataBuffer(hvcc_sample_buffer);
+  if (block_buffer == nullptr) {
+    RTC_LOG(LS_ERROR) << "Failed to get sample buffer's block buffer.";
+    return false;
+  }
+  CMBlockBufferRef contiguous_buffer = nullptr;
+  // Make sure block buffer is contiguous.
+  if (!CMBlockBufferIsRangeContiguous(block_buffer, 0, 0)) {
+    status = CMBlockBufferCreateContiguous(
+        nullptr, block_buffer, nullptr, nullptr, 0, 0, 0, &contiguous_buffer);
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to flatten non-contiguous block buffer: "
+                        << status;
+      return false;
+    }
+  } else {
+    contiguous_buffer = block_buffer;
+    // Retain to make cleanup easier.
+    CFRetain(contiguous_buffer);
+    block_buffer = nullptr;
+  }
+
+  // Now copy the actual data.
+  char* data_ptr = nullptr;
+  size_t block_buffer_size = CMBlockBufferGetDataLength(contiguous_buffer);
+  status = CMBlockBufferGetDataPointer(contiguous_buffer, 0, nullptr, nullptr,
+                                       &data_ptr);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get block buffer data.";
+    CFRelease(contiguous_buffer);
+    return false;
+  }
+  size_t bytes_remaining = block_buffer_size;
+  while (bytes_remaining > 0) {
+    // The size type here must match |nalu_header_size|, we expect 4 bytes.
+    // Read the length of the next packet of data. Must convert from big endian
+    // to host endian.
+    RTC_DCHECK_GE(bytes_remaining, (size_t)nalu_header_size);
+    uint32_t* uint32_data_ptr = reinterpret_cast<uint32_t*>(data_ptr);
+    uint32_t packet_size = CFSwapInt32BigToHost(*uint32_data_ptr);
+    // Update buffer.
+    annexb_buffer->AppendData(kAnnexBHeaderBytes, sizeof(kAnnexBHeaderBytes));
+    annexb_buffer->AppendData(data_ptr + nalu_header_size, packet_size);
+    // Update fragmentation.
+    frag_offsets.push_back(nalu_offset + sizeof(kAnnexBHeaderBytes));
+    frag_lengths.push_back(packet_size);
+    nalu_offset += sizeof(kAnnexBHeaderBytes) + packet_size;
+
+    size_t bytes_written = packet_size + sizeof(kAnnexBHeaderBytes);
+    bytes_remaining -= bytes_written;
+    data_ptr += bytes_written;
+  }
+  RTC_DCHECK_EQ(bytes_remaining, (size_t)0);
+
+  std::unique_ptr<RTPFragmentationHeader> header(new RTPFragmentationHeader());
+  header->VerifyAndAllocateFragmentationHeader(frag_offsets.size());
+  RTC_DCHECK_EQ(frag_lengths.size(), frag_offsets.size());
+  for (size_t i = 0; i < frag_offsets.size(); ++i) {
+    header->fragmentationOffset[i] = frag_offsets[i];
+    header->fragmentationLength[i] = frag_lengths[i];
+  }
+  *out_header = std::move(header);
+  CFRelease(contiguous_buffer);
+  return true;
+}
+
+bool H265AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
+                                      size_t annexb_buffer_size,
+                                      CMVideoFormatDescriptionRef video_format,
+                                      CMSampleBufferRef* out_sample_buffer) {
+  RTC_DCHECK(annexb_buffer);
+  RTC_DCHECK(out_sample_buffer);
+  RTC_DCHECK(video_format);
+  *out_sample_buffer = nullptr;
+
+  AnnexBBufferReader reader(annexb_buffer, annexb_buffer_size);
+  if (reader.SeekToNextNaluOfType(H265::kVps)) {
+    // Buffer contains an SPS NALU - skip it and the following PPS
+    const uint8_t* data;
+    size_t data_len;
+    if (!reader.ReadNalu(&data, &data_len)) {
+      RTC_LOG(LS_ERROR) << "Failed to read VPS";
+      return false;
+    }
+    if (!reader.ReadNalu(&data, &data_len)) {
+      RTC_LOG(LS_ERROR) << "Failed to read SPS";
+      return false;
+    }
+    if (!reader.ReadNalu(&data, &data_len)) {
+      RTC_LOG(LS_ERROR) << "Failed to read PPS";
+      return false;
+    }
+    if (reader.SeekToNextNaluOfType(H265::kPrefixSei)) {
+      if (!reader.ReadNalu(&data, &data_len)) {
+        RTC_LOG(LS_ERROR) << "Failed to read SEI";
+        return false;
+      }
+    }
+  } else {
+    // No SPS NALU - start reading from the first NALU in the buffer
+    reader.SeekToStart();
+  }
+
+  // Allocate memory as a block buffer.
+  // TODO(tkchin): figure out how to use a pool.
+  CMBlockBufferRef block_buffer = nullptr;
+  OSStatus status = CMBlockBufferCreateWithMemoryBlock(
+      nullptr, nullptr, reader.BytesRemaining(), nullptr, nullptr, 0,
+      reader.BytesRemaining(), kCMBlockBufferAssureMemoryNowFlag,
+      &block_buffer);
+  if (status != kCMBlockBufferNoErr) {
+    RTC_LOG(LS_ERROR) << "Failed to create block buffer.";
+    return false;
+  }
+
+  // Make sure block buffer is contiguous.
+  CMBlockBufferRef contiguous_buffer = nullptr;
+  if (!CMBlockBufferIsRangeContiguous(block_buffer, 0, 0)) {
+    status = CMBlockBufferCreateContiguous(
+        nullptr, block_buffer, nullptr, nullptr, 0, 0, 0, &contiguous_buffer);
+    if (status != noErr) {
+      RTC_LOG(LS_ERROR) << "Failed to flatten non-contiguous block buffer: "
+                        << status;
+      CFRelease(block_buffer);
+      return false;
+    }
+  } else {
+    contiguous_buffer = block_buffer;
+    block_buffer = nullptr;
+  }
+
+  // Get a raw pointer into allocated memory.
+  size_t block_buffer_size = 0;
+  char* data_ptr = nullptr;
+  status = CMBlockBufferGetDataPointer(contiguous_buffer, 0, nullptr,
+                                       &block_buffer_size, &data_ptr);
+  if (status != kCMBlockBufferNoErr) {
+    RTC_LOG(LS_ERROR) << "Failed to get block buffer data pointer.";
+    CFRelease(contiguous_buffer);
+    return false;
+  }
+  RTC_DCHECK(block_buffer_size == reader.BytesRemaining());
+
+  // Write Avcc NALUs into block buffer memory.
+  AvccBufferWriter writer(reinterpret_cast<uint8_t*>(data_ptr),
+                          block_buffer_size);
+  while (reader.BytesRemaining() > 0) {
+    const uint8_t* nalu_data_ptr = nullptr;
+    size_t nalu_data_size = 0;
+    if (reader.ReadNalu(&nalu_data_ptr, &nalu_data_size)) {
+      writer.WriteNalu(nalu_data_ptr, nalu_data_size);
+    }
+  }
+
+  // Create sample buffer.
+  status = CMSampleBufferCreate(nullptr, contiguous_buffer, true, nullptr,
+                                nullptr, video_format, 1, 0, nullptr, 0,
+                                nullptr, out_sample_buffer);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to create sample buffer.";
+    CFRelease(contiguous_buffer);
+    return false;
+  }
+  CFRelease(contiguous_buffer);
+  return true;
+}
+
 CMVideoFormatDescriptionRef CreateVideoFormatDescription(
     const uint8_t* annexb_buffer,
     size_t annexb_buffer_size) {
@@ -271,6 +498,41 @@ CMVideoFormatDescriptionRef CreateVideoFormatDescription(
   CMVideoFormatDescriptionRef description = nullptr;
   OSStatus status = CMVideoFormatDescriptionCreateFromH264ParameterSets(
       kCFAllocatorDefault, 2, param_set_ptrs, param_set_sizes, 4, &description);
+  if (status != noErr) {
+    RTC_LOG(LS_ERROR) << "Failed to create video format description.";
+    return nullptr;
+  }
+  return description;
+}
+
+CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+    const uint8_t* annexb_buffer,
+    size_t annexb_buffer_size) {
+  const uint8_t* param_set_ptrs[3] = {};
+  size_t param_set_sizes[3] = {};
+  AnnexBBufferReader reader(annexb_buffer, annexb_buffer_size);
+  // Skip everyting before the VPS, then read the VPS, SPS and PPS
+  if (!reader.SeekToNextNaluOfType(H265::kVps)) {
+    return nullptr;
+  }
+  if (!reader.ReadNalu(&param_set_ptrs[0], &param_set_sizes[0])) {
+    RTC_LOG(LS_ERROR) << "Failed to read VPS";
+    return nullptr;
+  }
+  if (!reader.ReadNalu(&param_set_ptrs[1], &param_set_sizes[1])) {
+    RTC_LOG(LS_ERROR) << "Failed to read SPS";
+    return nullptr;
+  }
+  if (!reader.ReadNalu(&param_set_ptrs[2], &param_set_sizes[2])) {
+    RTC_LOG(LS_ERROR) << "Failed to read PPS";
+    return nullptr;
+  }
+
+  // Parse the SPS and PPS into a CMVideoFormatDescription.
+  CMVideoFormatDescriptionRef description = nullptr;
+  OSStatus status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+      kCFAllocatorDefault, 3, param_set_ptrs, param_set_sizes, 4, nullptr,
+      &description);
   if (status != noErr) {
     RTC_LOG(LS_ERROR) << "Failed to create video format description.";
     return nullptr;
@@ -324,6 +586,17 @@ bool AnnexBBufferReader::SeekToNextNaluOfType(NaluType type) {
   }
   return false;
 }
+
+bool AnnexBBufferReader::SeekToNextNaluOfType(H265::NaluType type) {
+  for (; offset_ != offsets_.end(); ++offset_) {
+    if (offset_->payload_size < 1)
+      continue;
+    if (H265::ParseNaluType(*(start_ + offset_->payload_start_offset)) == type)
+      return true;
+  }
+  return false;
+}
+
 AvccBufferWriter::AvccBufferWriter(uint8_t* const avcc_buffer, size_t length)
     : start_(avcc_buffer), offset_(0), length_(length) {
   RTC_DCHECK(avcc_buffer);

--- a/sdk/objc/components/video_codec/nalu_rewriter.h
+++ b/sdk/objc/components/video_codec/nalu_rewriter.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "common_video/h264/h264_common.h"
+#include "common_video/h265/h265_common.h"
 #include "modules/include/module_common_types.h"
 #include "rtc_base/buffer.h"
 
@@ -47,12 +48,40 @@ bool H264AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
                                       CMSampleBufferRef* out_sample_buffer,
                                       CMMemoryPoolRef memory_pool);
 
+// Converts a sample buffer emitted from the VideoToolbox encoder into a buffer
+// suitable for RTP. The sample buffer is in hvcc format whereas the rtp buffer
+// needs to be in Annex B format. Data is written directly to |annexb_buffer|
+// and a new RTPFragmentationHeader is returned in |out_header|.
+bool H265CMSampleBufferToAnnexBBuffer(
+    CMSampleBufferRef hvcc_sample_buffer,
+    bool is_keyframe,
+    rtc::Buffer* annexb_buffer,
+    std::unique_ptr<RTPFragmentationHeader> *out_header)
+    __OSX_AVAILABLE_STARTING(__MAC_10_12, __IPHONE_11_0);
+
+ // Converts a buffer received from RTP into a sample buffer suitable for the
+// VideoToolbox decoder. The RTP buffer is in annex b format whereas the sample
+// buffer is in hvcc format.
+// If |is_keyframe| is true then |video_format| is ignored since the format will
+// be read from the buffer. Otherwise |video_format| must be provided.
+// Caller is responsible for releasing the created sample buffer.
+bool H265AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
+                                      size_t annexb_buffer_size,
+                                      CMVideoFormatDescriptionRef video_format,
+                                      CMSampleBufferRef* out_sample_buffer)
+    __OSX_AVAILABLE_STARTING(__MAC_10_12, __IPHONE_11_0);
+
 // Returns a video format description created from the sps/pps information in
 // the Annex B buffer. If there is no such information, nullptr is returned.
 // The caller is responsible for releasing the description.
 CMVideoFormatDescriptionRef CreateVideoFormatDescription(
     const uint8_t* annexb_buffer,
     size_t annexb_buffer_size);
+
+CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
+    const uint8_t* annexb_buffer,
+    size_t annexb_buffer_size)
+    __OSX_AVAILABLE_STARTING(__MAC_10_12, __IPHONE_11_0);
 
 // Helper class for reading NALUs from an RTP Annex B buffer.
 class AnnexBBufferReader final {
@@ -78,6 +107,7 @@ class AnnexBBufferReader final {
   // Return true if a NALU of the desired type is found, false if we
   // reached the end instead
   bool SeekToNextNaluOfType(H264::NaluType type);
+  bool SeekToNextNaluOfType(H265::NaluType type);
 
  private:
   // Returns the the next offset that contains NALU data.


### PR DESCRIPTION
This change applies 243912b03f7d089b1cdda31197baf05a2e37cb70 on m76 branch. It also fixes compile issues on iOS introduced by 6c5fb0208451b8fbfc15087465ea8c3dc9421c92.