### PR TITLE
Pick "Declare references as constant in the metal renderers."

### DIFF
--- a/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLI420Renderer.mm
@@ -33,10 +33,10 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       float2 texcoord;
     } Varyings;
 
-    vertex Varyings vertexPassthrough(device Vertex * verticies[[buffer(0)]],
+    vertex Varyings vertexPassthrough(constant Vertex *verticies[[buffer(0)]],
                                       unsigned int vid[[vertex_id]]) {
       Varyings out;
-      device Vertex &v = verticies[vid];
+      constant Vertex &v = verticies[vid];
       out.position = float4(float2(v.position), 0.0, 1.0);
       out.texcoord = v.texcoord;
 
@@ -44,7 +44,8 @@ static NSString *const shaderSource = MTL_STRINGIFY(
     }
 
     fragment half4 fragmentColorConversion(
-        Varyings in[[stage_in]], texture2d<float, access::sample> textureY[[texture(0)]],
+        Varyings in[[stage_in]],
+        texture2d<float, access::sample> textureY[[texture(0)]],
         texture2d<float, access::sample> textureU[[texture(1)]],
         texture2d<float, access::sample> textureV[[texture(2)]]) {
       constexpr sampler s(address::clamp_to_edge, filter::linear);

--- a/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.mm
@@ -34,10 +34,10 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       float2 texcoord;
     } Varyings;
 
-    vertex Varyings vertexPassthrough(device Vertex * verticies[[buffer(0)]],
+    vertex Varyings vertexPassthrough(constant Vertex *verticies[[buffer(0)]],
                                       unsigned int vid[[vertex_id]]) {
       Varyings out;
-      device Vertex &v = verticies[vid];
+      constant Vertex &v = verticies[vid];
       out.position = float4(float2(v.position), 0.0, 1.0);
       out.texcoord = v.texcoord;
       return out;
@@ -45,7 +45,8 @@ static NSString *const shaderSource = MTL_STRINGIFY(
 
     // Receiving YCrCb textures.
     fragment half4 fragmentColorConversion(
-        Varyings in[[stage_in]], texture2d<float, access::sample> textureY[[texture(0)]],
+        Varyings in[[stage_in]],
+        texture2d<float, access::sample> textureY[[texture(0)]],
         texture2d<float, access::sample> textureCbCr[[texture(1)]]) {
       constexpr sampler s(address::clamp_to_edge, filter::linear);
       float y;

--- a/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.mm
+++ b/sdk/objc/components/renderer/metal/RTCMTLRGBRenderer.mm
@@ -34,17 +34,17 @@ static NSString *const shaderSource = MTL_STRINGIFY(
       float2 texcoord;
     } VertexIO;
 
-    vertex VertexIO vertexPassthrough(device Vertex * verticies[[buffer(0)]],
+    vertex VertexIO vertexPassthrough(constant Vertex *verticies[[buffer(0)]],
                                       uint vid[[vertex_id]]) {
       VertexIO out;
-      device Vertex &v = verticies[vid];
+      constant Vertex &v = verticies[vid];
       out.position = float4(float2(v.position), 0.0, 1.0);
       out.texcoord = v.texcoord;
       return out;
     }
 
-    fragment half4 fragmentColorConversion(
-        VertexIO in[[stage_in]], texture2d<half, access::sample> texture[[texture(0)]],
+    fragment half4 fragmentColorConversion(VertexIO in[[stage_in]],
+                                           texture2d<half, access::sample> texture[[texture(0)]],
                                            constant bool &isARGB[[buffer(0)]]) {
       constexpr sampler s(address::clamp_to_edge, filter::linear);
 


### PR DESCRIPTION
Pick a change from libwebrtc to fix Metal issue on iOS 13.

Ref: https://webrtc.googlesource.com/src.git/+/93d4c10ffccc2faf2e38bab74ba14414751bae91.