### PR TITLE
Remove rtc_use_h265 setting in build.gni

### DIFF
--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -35,12 +35,6 @@ lint_suppressions_file = "//tools_webrtc/android/suppressions.xml"
 # so we just ignore that assert. See https://crbug.com/648948 for more info.
 ignore_elf32_limitations = true
 
-if (is_win || is_ios || is_android) {
-  rtc_use_h265 = true
-} else {
-  rtc_use_h265 = false
-}
-
 # Use bundled hermetic Xcode installation maintainted by Chromium,
 # except for local iOS builds where it's unsupported.
 if (host_os == "mac") {


### PR DESCRIPTION
Remove rtc_use_h265 setting in build.gni for server's linux build