### PR TITLE
Fix build error of libowt.so and pipe fd leak issue

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -419,7 +419,7 @@ if (!build_with_chromium) {
       visibility += [ "//talk/owt" ]
     }
     sources = []
-    complete_static_lib = true
+    # complete_static_lib = true
     suppressed_configs += [ "//build/config/compiler:thin_archive" ]
     defines = []
 

--- a/rtc_base/thread.cc
+++ b/rtc_base/thread.cc
@@ -82,8 +82,8 @@ Thread* Thread::Current() {
 #ifndef NO_MAIN_THREAD_WRAPPING
   // Only autowrap the thread which instantiated the ThreadManager.
   if (!thread && manager->IsMainThread()) {
-    thread = new Thread(SocketServer::CreateDefault());
-    thread->WrapCurrentWithThreadManager(manager, true);
+    //thread = new Thread(SocketServer::CreateDefault());
+    //thread->WrapCurrentWithThreadManager(manager, true);
   }
 #endif
 


### PR DESCRIPTION
When building libowt.so, it will has symbols multiple definition issue, so remove complete_static_lib to fix it. The second patch is to fix pipe fd leak issue in webrtc.