### PR TITLE
Do not initialize audio recording device.

### DIFF
--- a/media/engine/adm_helpers.cc
+++ b/media/engine/adm_helpers.cc
@@ -57,6 +57,7 @@ void Init(AudioDeviceModule* adm) {
     }
   }
 
+#if defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
   // Recording device.
   {
     if (adm->SetRecordingDevice(AUDIO_DEVICE_ID) != 0) {
@@ -76,6 +77,7 @@ void Init(AudioDeviceModule* adm) {
       RTC_LOG(LS_ERROR) << "Failed to set stereo recording mode.";
     }
   }
+#endif
 }
 }  // namespace adm_helpers
 }  // namespace webrtc


### PR DESCRIPTION
We use custom audio input in cloud gaming scenarios, so there is no need to initialize audio recording device. We don't need audio playback at server side as well.