### PR TITLE
Re-enable ffmpeg build with msvc

### DIFF
--- a/modules/video_coding/codecs/h264/h264_color_space.h
+++ b/modules/video_coding/codecs/h264/h264_color_space.h
@@ -16,10 +16,6 @@
 // #ifdef unless needed and tested.
 #ifdef WEBRTC_USE_H264
 
-#if defined(WEBRTC_WIN) && !defined(__clang__)
-#error "See: bugs.webrtc.org/9213#c13."
-#endif
-
 #include "api/video/color_space.h"
 
 extern "C" {

--- a/modules/video_coding/codecs/h264/h264_decoder_impl.h
+++ b/modules/video_coding/codecs/h264/h264_decoder_impl.h
@@ -17,10 +17,6 @@
 // #ifdef unless needed and tested.
 #ifdef WEBRTC_USE_H264
 
-#if defined(WEBRTC_WIN) && !defined(__clang__)
-#error "See: bugs.webrtc.org/9213#c13."
-#endif
-
 #include <memory>
 
 #include "modules/video_coding/codecs/h264/include/h264.h"

--- a/modules/video_coding/codecs/h264/h264_encoder_impl.h
+++ b/modules/video_coding/codecs/h264/h264_encoder_impl.h
@@ -17,10 +17,6 @@
 // #ifdef unless needed and tested.
 #ifdef WEBRTC_USE_H264
 
-#if defined(WEBRTC_WIN) && !defined(__clang__)
-#error "See: bugs.webrtc.org/9213#c13."
-#endif
-
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Upstream webrtc disable ffmpeg decoder if msvc is used. Re-enable it here.