### PR TITLE
Only set marker bit on last slice.

### DIFF
--- a/modules/rtp_rtcp/source/rtp_format.cc
+++ b/modules/rtp_rtcp/source/rtp_format.cc
@@ -50,7 +50,7 @@ std::unique_ptr<RtpPacketizer> RtpPacketizer::Create(
       const auto& h264 =
           absl::get<RTPVideoHeaderH264>(rtp_video_header.video_type_header);
       return std::make_unique<RtpPacketizerH264>(
-          payload, limits, h264.packetization_mode, *fragmentation);
+          payload, limits, h264.packetization_mode, *fragmentation, end_of_frame);
     }
 #ifndef DISABLE_H265
     case kVideoCodecH265: {
@@ -58,7 +58,7 @@ std::unique_ptr<RtpPacketizer> RtpPacketizer::Create(
       const auto& h265 =
           absl::get<RTPVideoHeaderH265>(rtp_video_header.video_type_header);
       return absl::make_unique<RtpPacketizerH265>(
-          payload, limits, h265.packetization_mode, *fragmentation);
+          payload, limits, h265.packetization_mode, *fragmentation, end_of_frame);
     }
 #endif
     case kVideoCodecVP8: {

--- a/modules/rtp_rtcp/source/rtp_format_h265.cc
+++ b/modules/rtp_rtcp/source/rtp_format_h265.cc
@@ -80,9 +80,11 @@ RtpPacketizerH265::RtpPacketizerH265(
     rtc::ArrayView<const uint8_t> payload,
     PayloadSizeLimits limits,
     H265PacketizationMode packetization_mode,
-    const RTPFragmentationHeader& fragmentation)
+    const RTPFragmentationHeader& fragmentation,
+    bool end_of_frame)
     : limits_(limits),
-      num_packets_left_(0) {
+      num_packets_left_(0),
+      end_of_frame_(end_of_frame) {
   // Guard against uninitialized memory in packetization_mode.
   RTC_CHECK(packetization_mode == H265PacketizationMode::NonInterleaved ||
             packetization_mode == H265PacketizationMode::SingleNalUnit);
@@ -294,7 +296,7 @@ bool RtpPacketizerH265::NextPacket(RtpPacketToSend* rtp_packet) {
   } else {
     NextFragmentPacket(rtp_packet);
   }
-  rtp_packet->SetMarker(packets_.empty());
+  rtp_packet->SetMarker(packets_.empty() && end_of_frame_);
   --num_packets_left_;
   return true;
 }

--- a/modules/rtp_rtcp/source/rtp_format_h265.h
+++ b/modules/rtp_rtcp/source/rtp_format_h265.h
@@ -32,7 +32,8 @@ class RtpPacketizerH265 : public RtpPacketizer {
   RtpPacketizerH265(rtc::ArrayView<const uint8_t> payload,
                     PayloadSizeLimits limits,
                     H265PacketizationMode packetization_mode,
-                    const RTPFragmentationHeader& fragmentation);
+                    const RTPFragmentationHeader& fragmentation,
+                    bool end_of_frame = true);
 
    ~RtpPacketizerH265() override;
 
@@ -109,7 +110,7 @@ class RtpPacketizerH265 : public RtpPacketizer {
   const PayloadSizeLimits limits_;
   size_t num_packets_left_;
   RTPFragmentationHeader fragmentation_;
-
+  bool end_of_frame_ = true;
   RTC_DISALLOW_COPY_AND_ASSIGN(RtpPacketizerH265);
 };
 }  // namespace webrtc


### PR DESCRIPTION
Re-enable slice/tile based transmission for H.264/H.265.