### PR TITLE
Only insert sps/pps/vps for key frame of hevc.

### DIFF
--- a/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java
+++ b/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java
@@ -563,7 +563,7 @@ class HardwareVideoEncoder implements VideoEncoder {
         }
 
         final ByteBuffer frameBuffer;
-        if (isKeyFrame && codecType == VideoCodecMimeType.H264 || codecType == VideoCodecMimeType.H265) {
+        if (isKeyFrame && (codecType == VideoCodecMimeType.H264 || codecType == VideoCodecMimeType.H265)) {
           Logging.d(TAG,
               "Prepending config frame of size " + configBuffer.capacity()
                   + " to output buffer with offset " + info.offset + ", size " + info.size);


### PR DESCRIPTION
A mis-condition applied for inserting sps/pps/vps for hevc stream in android encoder.