### PR TITLE
Enable automatic audio playback device switching

### DIFF
--- a/modules/audio_device/win/audio_device_core_win.cc
+++ b/modules/audio_device/win/audio_device_core_win.cc
@@ -168,10 +168,40 @@ class MediaBufferImpl final : public IMediaBuffer {
 //                              Static Methods
 // ============================================================================
 
+HRESULT __stdcall AudioDeviceWindowsCore::OnDefaultDeviceChanged(
+   EDataFlow flow,
+   ERole role,
+   LPCWSTR pwstrDefaultDeviceId) {
+  if (flow != eRender || role != eCommunications)
+    SetEvent(_hDeviceRestartEvent);
+  return S_OK;
+}
+
+ULONG AudioDeviceWindowsCore::AddRef() {
+  ULONG new_ref = InterlockedIncrement(&ref_count_);
+  return new_ref;
+}
+
+ULONG AudioDeviceWindowsCore::Release() {
+  ULONG new_ref = InterlockedDecrement(&ref_count_);
+  return new_ref;
+}
+
+HRESULT AudioDeviceWindowsCore::QueryInterface(REFIID iid, void** object) {
+  if (object == nullptr) {
+    return E_POINTER;
+  }
+  if (iid == IID_IUnknown || iid == __uuidof(IMMNotificationClient)) {
+    *object = static_cast<IMMNotificationClient*>(this);
+    return S_OK;
+  };
+  *object = nullptr;
+  return E_NOINTERFACE;
+}
+
 // ----------------------------------------------------------------------------
 //  CoreAudioIsSupported
 // ----------------------------------------------------------------------------
-
 bool AudioDeviceWindowsCore::CoreAudioIsSupported() {
   RTC_LOG(LS_VERBOSE) << __FUNCTION__;
 
@@ -369,6 +399,7 @@ AudioDeviceWindowsCore::AudioDeviceWindowsCore()
       _hRecThread(NULL),
       _hCaptureStartedEvent(NULL),
       _hShutdownCaptureEvent(NULL),
+      _hDeviceRestartEvent(NULL),
       _hMmTask(NULL),
       _playAudioFrameSize(0),
       _playSampleRate(0),
@@ -444,6 +475,7 @@ AudioDeviceWindowsCore::AudioDeviceWindowsCore()
   _hShutdownCaptureEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
   _hRenderStartedEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
   _hCaptureStartedEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+  _hDeviceRestartEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
   _perfCounterFreq.QuadPart = 1;
   _perfCounterFactor = 0.0;
@@ -470,6 +502,7 @@ AudioDeviceWindowsCore::AudioDeviceWindowsCore()
                    reinterpret_cast<void**>(&_ptrEnumerator));
   assert(NULL != _ptrEnumerator);
 
+  _ptrEnumerator->RegisterEndpointNotificationCallback(this);
   // DMO initialization for built-in WASAPI AEC.
   {
     IMediaObject* ptrDMO = NULL;
@@ -497,6 +530,9 @@ AudioDeviceWindowsCore::~AudioDeviceWindowsCore() {
 
   // The IMMDeviceEnumerator is created during construction. Must release
   // it here and not in Terminate() since we don't recreate it in Init().
+  if (_ptrEnumerator) {
+    _ptrEnumerator->UnregisterEndpointNotificationCallback(this);
+  }
   SAFE_RELEASE(_ptrEnumerator);
 
   _ptrAudioBuffer = NULL;
@@ -529,6 +565,11 @@ AudioDeviceWindowsCore::~AudioDeviceWindowsCore() {
   if (NULL != _hShutdownCaptureEvent) {
     CloseHandle(_hShutdownCaptureEvent);
     _hShutdownCaptureEvent = NULL;
+  }
+
+  if (NULL != _hDeviceRestartEvent) {
+    CloseHandle(_hDeviceRestartEvent);
+    _hDeviceRestartEvent = NULL;
   }
 
   if (_avrtLibrary) {
@@ -2635,7 +2676,7 @@ DWORD WINAPI AudioDeviceWindowsCore::WSAPICaptureThreadPollDMO(LPVOID context) {
 
 DWORD AudioDeviceWindowsCore::DoRenderThread() {
   bool keepPlaying = true;
-  HANDLE waitArray[2] = {_hShutdownRenderEvent, _hRenderSamplesReadyEvent};
+  HANDLE waitArray[3] = {_hShutdownRenderEvent, _hRenderSamplesReadyEvent, _hDeviceRestartEvent};
   HRESULT hr = S_OK;
   HANDLE hMmTask = NULL;
 
@@ -2752,12 +2793,16 @@ DWORD AudioDeviceWindowsCore::DoRenderThread() {
 
   while (keepPlaying) {
     // Wait for a render notification event or a shutdown event
-    DWORD waitResult = WaitForMultipleObjects(2, waitArray, FALSE, 500);
+    DWORD waitResult = WaitForMultipleObjects(3, waitArray, FALSE, 500);
     switch (waitResult) {
       case WAIT_OBJECT_0 + 0:  // _hShutdownRenderEvent
         keepPlaying = false;
         break;
       case WAIT_OBJECT_0 + 1:  // _hRenderSamplesReadyEvent
+        break;
+      case WAIT_OBJECT_0 + 2:  // _hDeviceRestartEvent
+        // TODO: if we're going to switch back to this platform specific impl,
+        // We should restart the playout session here.
         break;
       case WAIT_TIMEOUT:  // timeout notification
         RTC_LOG(LS_WARNING) << "render event timed out after 0.5 seconds";

--- a/modules/audio_device/win/audio_device_core_win.h
+++ b/modules/audio_device/win/audio_device_core_win.h
@@ -76,12 +76,18 @@ class ScopedCOMInitializer {
   void operator=(const ScopedCOMInitializer&);
 };
 
-class AudioDeviceWindowsCore : public AudioDeviceGeneric {
+class AudioDeviceWindowsCore : public AudioDeviceGeneric,
+                               public IMMNotificationClient {
  public:
   AudioDeviceWindowsCore();
   ~AudioDeviceWindowsCore();
 
   static bool CoreAudioIsSupported();
+
+  // IUnknown (required by IMMNotificationClient).
+  ULONG __stdcall AddRef() override;
+  ULONG __stdcall Release() override;
+  HRESULT __stdcall QueryInterface(REFIID iid, void** object) override;
 
   // Retrieve the currently utilized audio layer
   virtual int32_t ActiveAudioLayer(
@@ -262,6 +268,7 @@ class AudioDeviceWindowsCore : public AudioDeviceGeneric {
   HANDLE _hPlayThread;
   HANDLE _hRenderStartedEvent;
   HANDLE _hShutdownRenderEvent;
+  HANDLE _hDeviceRestartEvent;
 
   HANDLE _hCaptureSamplesReadyEvent;
   HANDLE _hRecThread;
@@ -292,6 +299,30 @@ class AudioDeviceWindowsCore : public AudioDeviceGeneric {
   double _perfCounterFactor;
 
  private:
+  // IMMNotificationClient implementation. At present we
+  // only handle OnDefaultDeviceChanged event.
+  HRESULT __stdcall OnDeviceStateChanged(LPCWSTR pwstrDeviceId,
+                                         DWORD dwNewState) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDeviceAdded(LPCWSTR pwstrDeviceId) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDeviceRemoved(LPCWSTR pwstrDeviceId) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDefaultDeviceChanged(
+      EDataFlow flow,
+      ERole role,
+      LPCWSTR pwstrDefaultDeviceId) override;
+
+  HRESULT __stdcall OnPropertyValueChanged(LPCWSTR pwstrDeviceId,
+                                           const PROPERTYKEY key) override {
+    return S_OK;
+  }
   bool _initialized;
   bool _recording;
   bool _playing;
@@ -306,6 +337,7 @@ class AudioDeviceWindowsCore : public AudioDeviceGeneric {
   AudioDeviceModule::WindowsDeviceType _outputDevice;
   uint16_t _inputDeviceIndex;
   uint16_t _outputDeviceIndex;
+  LONG ref_count_ = 1;
 };
 
 #endif  // #if (_MSC_VER >= 1400)

--- a/modules/audio_device/win/core_audio_base_win.cc
+++ b/modules/audio_device/win/core_audio_base_win.cc
@@ -181,9 +181,15 @@ CoreAudioBase::CoreAudioBase(Direction direction,
   // invalidated or the stream format has changed.
   restart_event_.Set(CreateEvent(nullptr, false, false, nullptr));
   RTC_DCHECK(restart_event_.IsValid());
+
+  enumerator_ = core_audio_utility::CreateDeviceEnumerator();
+  enumerator_->RegisterEndpointNotificationCallback(this);
+  RTC_LOG(INFO) << __FUNCTION__
+                    << ":Registered endpoint notification callback.";
 }
 
 CoreAudioBase::~CoreAudioBase() {
+  enumerator_->UnregisterEndpointNotificationCallback(this);
   RTC_DLOG(INFO) << __FUNCTION__;
   RTC_DCHECK_EQ(ref_count_, 1);
 }
@@ -872,6 +878,18 @@ HRESULT CoreAudioBase::OnChannelVolumeChanged(DWORD channel_count,
 // IAudioSessionEvents::OnGroupingParamChanged
 HRESULT CoreAudioBase::OnGroupingParamChanged(LPCGUID new_grouping_param,
                                               LPCGUID event_context) {
+  return S_OK;
+}
+
+// IMMNotificationClient::OnDefaultDeviceChanged
+HRESULT __stdcall CoreAudioBase::OnDefaultDeviceChanged(EDataFlow flow,
+                                         ERole role,
+                                         LPCWSTR pwstrDefaultDeviceId) {
+  // We only handle the output device.
+  RTC_LOG(LS_ERROR) << "OnDefaultDeviceChanged invoked.";
+  if (flow != eRender || role != eCommunications)
+    return S_OK;
+  Restart();
   return S_OK;
 }
 

--- a/modules/audio_device/win/core_audio_base_win.h
+++ b/modules/audio_device/win/core_audio_base_win.h
@@ -39,7 +39,7 @@ namespace webrtc_win {
 // a separate thread owned and controlled by the manager.
 // TODO(henrika): investigate if CoreAudioBase should implement
 // IMMNotificationClient as well (might improve support for device changes).
-class CoreAudioBase : public IAudioSessionEvents {
+class CoreAudioBase : public IAudioSessionEvents, public IMMNotificationClient {
  public:
   enum class Direction {
     kInput,
@@ -160,6 +160,7 @@ class CoreAudioBase : public IAudioSessionEvents {
   std::atomic<bool> is_restarting_;
   std::unique_ptr<rtc::PlatformThread> audio_thread_;
   Microsoft::WRL::ComPtr<IAudioSessionControl> audio_session_control_;
+  Microsoft::WRL::ComPtr<IMMDeviceEnumerator> enumerator_;
 
   void StopThread();
   AudioSessionState GetAudioSessionState() const;
@@ -194,6 +195,31 @@ class CoreAudioBase : public IAudioSessionEvents {
                                            LPCGUID event_context) override;
   HRESULT __stdcall OnGroupingParamChanged(LPCGUID new_grouping_param,
                                            LPCGUID event_context) override;
+
+  // IMMNotificationClient implementation. At present we
+  // only handle OnDefaultDeviceChanged event.
+  HRESULT __stdcall OnDeviceStateChanged(LPCWSTR pwstrDeviceId,
+                                         DWORD dwNewState) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDeviceAdded(LPCWSTR pwstrDeviceId) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDeviceRemoved(LPCWSTR pwstrDeviceId) override {
+    return S_OK;
+  }
+
+  HRESULT __stdcall OnDefaultDeviceChanged(
+      EDataFlow flow,
+      ERole role,
+      LPCWSTR pwstrDefaultDeviceId) override;
+
+  HRESULT __stdcall OnPropertyValueChanged(LPCWSTR pwstrDeviceId,
+                                           const PROPERTYKEY key) override {
+    return S_OK;
+  }
 };
 
 }  // namespace webrtc_win

--- a/modules/audio_device/win/core_audio_output_win.cc
+++ b/modules/audio_device/win/core_audio_output_win.cc
@@ -410,10 +410,10 @@ bool CoreAudioOutput::HandleStreamDisconnected() {
   if (InitPlayout() != 0) {
     return false;
   }
+
   if (StartPlayout() != 0) {
     return false;
   }
-
   RTC_DLOG(INFO) << __FUNCTION__ << " --->>>";
   return true;
 }


### PR DESCRIPTION
OWT Win SDK will move from audio_device_core_win core_audio_xxx impl.