### PR TITLE
Do not check last_fragment flag for non h.264/h.265 stream

### DIFF
--- a/call/rtp_video_sender.cc
+++ b/call/rtp_video_sender.cc
@@ -530,11 +530,14 @@ EncodedImageCallback::Result RtpVideoSender::OnEncodedImage(
   }
   RTPVideoHeader rtp_video_header = params_[stream_index].GetRtpVideoHeader(
       encoded_image, codec_specific_info, shared_frame_id_);
-  if (codec_specific_info->codecSpecific.H264.last_fragment_in_frame)
+  if (codec_specific_info->codecType == kVideoCodecH264 &&
+      codec_specific_info->codecSpecific.H264.last_fragment_in_frame)
     absl::get<RTPVideoHeaderH264>(rtp_video_header.video_type_header)
         .has_last_fragement = true;
 #ifndef DISABLE_H265
-  else if (codec_specific_info->codecSpecific.H265.last_fragment_in_frame)
+  else if (codec_specific_info->codecType ==
+           kVideoCodecH265 && codec_specific_info->codecSpecific.H265
+               .last_fragment_in_frame)
     absl::get<RTPVideoHeaderH265>(rtp_video_header.video_type_header)
         .has_last_fragement = true;
 #endif


### PR DESCRIPTION
when checking codec specific header, make sure we're at the right codec.