### PR TITLE
Identify keyframe packets for FEC protection

### DIFF
--- a/modules/rtp_rtcp/source/rtp_sender_video.cc
+++ b/modules/rtp_rtcp/source/rtp_sender_video.cc
@@ -619,6 +619,8 @@ bool RTPSenderVideo::SendVideo(
 
     packet->set_allow_retransmission(allow_retransmission);
 
+    packet->set_is_key_frame(video_header.frame_type == VideoFrameType::kVideoFrameKey);
+
     // Put packetization finish timestamp into extension.
     if (packet->HasExtension<VideoTimingExtension>()) {
       packet->set_packetization_finish_time_ms(clock_->TimeInMilliseconds());


### PR DESCRIPTION
There is code to set different protection levels for keyframes vs.
delta frames, but because this set_is_keyframe was never called,
the distinction was never used.