### PR TITLE
Revert "Identify keyframe packets for FEC protection"

### DIFF
--- a/modules/rtp_rtcp/source/rtp_sender_video.cc
+++ b/modules/rtp_rtcp/source/rtp_sender_video.cc
@@ -619,8 +619,6 @@ bool RTPSenderVideo::SendVideo(
 
     packet->set_allow_retransmission(allow_retransmission);
 
-    packet->set_is_key_frame(video_header.frame_type == VideoFrameType::kVideoFrameKey);
-
     // Put packetization finish timestamp into extension.
     if (packet->HasExtension<VideoTimingExtension>()) {
       packet->set_packetization_finish_time_ms(clock_->TimeInMilliseconds());


### PR DESCRIPTION
Reverts open-webrtc-toolkit/owt-deps-webrtc#104

Reason for revert: ulpfec generator will check if current packet's frame type with previous one in debug mode. With this change, in case there're pending packet in media_packets_ array, there would be crash. 