### PR TITLE
Identify keyframe packets for FEC protection

### DIFF
--- a/modules/rtp_rtcp/source/rtp_sender_video.cc
+++ b/modules/rtp_rtcp/source/rtp_sender_video.cc
@@ -619,6 +619,8 @@ bool RTPSenderVideo::SendVideo(
 
     packet->set_allow_retransmission(allow_retransmission);
 
+    packet->set_is_key_frame(video_header.frame_type == VideoFrameType::kVideoFrameKey);
+
     // Put packetization finish timestamp into extension.
     if (packet->HasExtension<VideoTimingExtension>()) {
       packet->set_packetization_finish_time_ms(clock_->TimeInMilliseconds());

--- a/modules/rtp_rtcp/source/ulpfec_generator.cc
+++ b/modules/rtp_rtcp/source/ulpfec_generator.cc
@@ -111,6 +111,11 @@ void UlpfecGenerator::AddPacketAndGenerateFec(const RtpPacketToSend& packet) {
   RTC_DCHECK_RUNS_SERIALIZED(&race_checker_);
   RTC_DCHECK(generated_fec_packets_.empty());
 
+  // reset state upon async keyframe request
+  if (keyframe_in_process_ != packet.is_key_frame()) {
+    ResetState();
+  }
+
   if (media_packets_.empty()) {
     rtc::CritScope cs(&crit_);
     if (pending_params_) {
@@ -126,7 +131,6 @@ void UlpfecGenerator::AddPacketAndGenerateFec(const RtpPacketToSend& packet) {
 
     keyframe_in_process_ = packet.is_key_frame();
   }
-  RTC_DCHECK_EQ(packet.is_key_frame(), keyframe_in_process_);
 
   bool complete_frame = false;
   const bool marker_bit = packet.Marker();


### PR DESCRIPTION
There is code to set different protection levels for keyframes vs.
delta frames, but because this set_is_key_frame was never called,
the distinction was never used.

Also, clear old media packets from a previous frame, which can
happen if a keyframe request comes from the receiver.