### PR TITLE
Add missing CODEC_H265 switch case

### DIFF
--- a/logging/rtc_event_log/rtc_event_log_parser.cc
+++ b/logging/rtc_event_log/rtc_event_log_parser.cc
@@ -305,8 +305,10 @@ VideoCodecType GetRuntimeCodecType(rtclog2::FrameDecodedEvents::Codec codec) {
       return VideoCodecType::kVideoCodecAV1;
     case rtclog2::FrameDecodedEvents::CODEC_H264:
       return VideoCodecType::kVideoCodecH264;
+#ifndef DISABLE_H265 
     case rtclog2::FrameDecodedEvents::CODEC_H265:
       return VideoCodecType::kVideoCodecH265;
+#endif 
     case rtclog2::FrameDecodedEvents::CODEC_UNKNOWN:
       RTC_LOG(LS_ERROR) << "Unknown codec type. Assuming "
                            "VideoCodecType::kVideoCodecMultiplex";

--- a/logging/rtc_event_log/rtc_event_log_parser.cc
+++ b/logging/rtc_event_log/rtc_event_log_parser.cc
@@ -305,6 +305,8 @@ VideoCodecType GetRuntimeCodecType(rtclog2::FrameDecodedEvents::Codec codec) {
       return VideoCodecType::kVideoCodecAV1;
     case rtclog2::FrameDecodedEvents::CODEC_H264:
       return VideoCodecType::kVideoCodecH264;
+    case rtclog2::FrameDecodedEvents::CODEC_H265:
+      return VideoCodecType::kVideoCodecH265;
     case rtclog2::FrameDecodedEvents::CODEC_UNKNOWN:
       RTC_LOG(LS_ERROR) << "Unknown codec type. Assuming "
                            "VideoCodecType::kVideoCodecMultiplex";


### PR DESCRIPTION
Add missing `rtclog2::FrameDecodedEvents::CODEC_H265` switch case in `rtc_event_log_parser.cc` to prevent compiling errors/failures on external projects. 