### PR TITLE
Remove rtc_use_265 override in webrtc tree.

### DIFF
--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -35,12 +35,6 @@ ubsan_vptr_blacklist_path =
 # so we just ignore that assert. See https://crbug.com/648948 for more info.
 ignore_elf32_limitations = true
 
-if (is_win || is_ios || is_android) {
-  rtc_use_h265 = true
-} else {
-  rtc_use_h265 = false
-}
-
 # Use bundled hermetic Xcode installation maintainted by Chromium,
 # except for local iOS builds where it's unsupported.
 if (host_os == "mac") {

--- a/p2p/base/dtls_transport_unittest.cc
+++ b/p2p/base/dtls_transport_unittest.cc
@@ -76,7 +76,7 @@ class DtlsTestClient : public sigslot::has_slots<> {
   }
   // Set up fake ICE transport and real DTLS transport under test.
   void SetupTransports(IceRole role, int async_delay_ms = 0) {
-    fake_ice_transport_.reset(new FakeIceTransport("fake", cricket::MEDIA_TYPE_VIDEO, 0));
+    fake_ice_transport_.reset(new FakeIceTransport("fake", 0));
     fake_ice_transport_->SetAsync(true);
     fake_ice_transport_->SetAsyncDelay(async_delay_ms);
     fake_ice_transport_->SetIceRole(role);


### PR DESCRIPTION
webrtc tree is currently not build independently, so all declaration/overrides shared by SDK/webrtc should go to sdk repo, to avoid mismatch of implementation.