### PR TITLE
wget gn through https

### DIFF
--- a/tools-woogeen/install.sh
+++ b/tools-woogeen/install.sh
@@ -76,7 +76,7 @@ name=buildtools
 dst=buildtools
 download_project ${repo} ${commit} ${download_dir} ${name} ${SOURCE}/${dst}
 
-wget --no-check-certificate http://storage.googleapis.com/chromium-gn/a452edf26a551fef8a884496d143b7e56cbe2ad9 -O ${SOURCE}/${dst}/linux64/gn
+wget https://storage.googleapis.com/chromium-gn/a452edf26a551fef8a884496d143b7e56cbe2ad9 -O ${SOURCE}/${dst}/linux64/gn
 chmod +x ${SOURCE}/${dst}/linux64/gn
 
 # base


### PR DESCRIPTION
google is not supporting http any more.   without reverting this change, my ci job will fail to wget.

if wget https is failed during owt-server build, 90% of the root cause is LD_LIBRARY_PATH contains build/libdeps/.../libssl*.so .  and ubuntu ssl/cert lib is ignored.