### PR TITLE
Put attribute before function name instead of after, as required by GCC

### DIFF
--- a/webrtc/common_audio/vad/vad_core.c
+++ b/webrtc/common_audio/vad/vad_core.c
@@ -115,8 +115,8 @@ static int32_t WeightedAverage(int16_t* data, int16_t offset,
 // undefined behavior, so not a good idea; this just makes UBSan ignore the
 // violation, so that our old code can continue to do what it's always been
 // doing.)
-static inline int32_t OverflowingMulS16ByS32ToS32(int16_t a, int32_t b)
-    RTC_NO_SANITIZE("signed-integer-overflow") {
+static inline int32_t RTC_NO_SANITIZE("signed-integer-overflow")
+    OverflowingMulS16ByS32ToS32(int16_t a, int32_t b) {
   return a * b;
 }
 

--- a/webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.c
+++ b/webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.c
@@ -193,16 +193,16 @@ static void CalcCorrelation(int32_t *PSpecQ12, int32_t *CorrQ7)
 // undefined behavior, so not a good idea; this just makes UBSan ignore the
 // violations, so that our old code can continue to do what it's always been
 // doing.)
-static inline int32_t OverflowingMulS16S32ToS32(int16_t a, int32_t b)
-    RTC_NO_SANITIZE("signed-integer-overflow") {
+static inline int32_t RTC_NO_SANITIZE("signed-integer-overflow")
+    OverflowingMulS16S32ToS32(int16_t a, int32_t b) {
   return a * b;
 }
-static inline int32_t OverflowingAddS32S32ToS32(int32_t a, int32_t b)
-    RTC_NO_SANITIZE("signed-integer-overflow") {
+static inline int32_t RTC_NO_SANITIZE("signed-integer-overflow")
+    OverflowingAddS32S32ToS32(int32_t a, int32_t b) {
   return a + b;
 }
-static inline int32_t OverflowingSubS32S32ToS32(int32_t a, int32_t b)
-    RTC_NO_SANITIZE("signed-integer-overflow") {
+static inline int32_t RTC_NO_SANITIZE("signed-integer-overflow")
+    OverflowingSubS32S32ToS32(int32_t a, int32_t b) {
   return a - b;
 }
 

--- a/webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c
+++ b/webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c
@@ -209,8 +209,8 @@ void WebRtcIsacfix_NormLatticeFilterMa(size_t orderCoef,
 // Left shift of an int32_t that's allowed to overflow. (It's still undefined
 // behavior, so not a good idea; this just makes UBSan ignore the violation, so
 // that our old code can continue to do what it's always been doing.)
-static inline int32_t OverflowingLShiftS32(int32_t x, int shift)
-    RTC_NO_SANITIZE("shift") {
+static inline int32_t RTC_NO_SANITIZE("shift")
+    OverflowingLShiftS32(int32_t x, int shift) {
   return x << shift;
 }
 


### PR DESCRIPTION
As suggested by marxin.liska@gmail.com in bug 7857.

BUG=webrtc:7857

Review-Url: https://codereview.webrtc.org/2947383002
Cr-Commit-Position: refs/heads/master@{#18757}


(cherry picked from commit d3cf0476b4c7923b6c0b8d25ce85769f6686b794)