### PR TITLE
Enable HEVC support.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -257,8 +257,8 @@ config("common_inherited_config") {
     cflags += [ "-fsanitize=float-cast-overflow" ]
   }
 
-  if (!rtc_use_h265) {
-    defines += [ "DISABLE_H265" ]
+  if (rtc_use_h265) {
+    defines += [ "WEBRTC_USE_H265" ]
   }
 }
 
@@ -315,6 +315,10 @@ config("common_config") {
 
   if (rtc_use_h264) {
     defines += [ "WEBRTC_USE_H264" ]
+  }
+
+  if (rtc_use_h265) {
+    defines += [ "WEBRTC_USE_H265" ]
   }
 
   if (rtc_use_absl_mutex) {

--- a/api/video/video_codec_type.h
+++ b/api/video/video_codec_type.h
@@ -21,9 +21,7 @@ enum VideoCodecType {
   kVideoCodecVP9,
   kVideoCodecAV1,
   kVideoCodecH264,
-#ifndef DISABLE_H265
   kVideoCodecH265,
-#endif
   kVideoCodecMultiplex,
 };
 

--- a/api/video_codecs/video_codec.cc
+++ b/api/video_codecs/video_codec.cc
@@ -26,7 +26,7 @@ constexpr char kPayloadNameAv1[] = "AV1";
 // needed.
 constexpr char kPayloadNameAv1x[] = "AV1X";
 constexpr char kPayloadNameH264[] = "H264";
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 constexpr char kPayloadNameH265[] = "H265";
 #endif
 constexpr char kPayloadNameGeneric[] = "Generic";
@@ -55,7 +55,7 @@ bool VideoCodecH264::operator==(const VideoCodecH264& other) const {
           numberOfTemporalLayers == other.numberOfTemporalLayers);
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 bool VideoCodecH265::operator==(const VideoCodecH265& other) const {
   return (frameDroppingOn == other.frameDroppingOn &&
           keyFrameInterval == other.keyFrameInterval &&
@@ -116,7 +116,7 @@ const VideoCodecH264& VideoCodec::H264() const {
   return codec_specific_.H264;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 VideoCodecH265* VideoCodec::H265() {
   RTC_DCHECK_EQ(codecType, kVideoCodecH265);
   return &codec_specific_.H265;
@@ -138,7 +138,7 @@ const char* CodecTypeToPayloadString(VideoCodecType type) {
       return kPayloadNameAv1;
     case kVideoCodecH264:
       return kPayloadNameH264;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265:
       return kPayloadNameH265;
 #endif
@@ -163,7 +163,7 @@ VideoCodecType PayloadStringToCodecType(const std::string& name) {
     return kVideoCodecH264;
   if (absl::EqualsIgnoreCase(name, kPayloadNameMultiplex))
     return kVideoCodecMultiplex;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   if (absl::EqualsIgnoreCase(name, kPayloadNameH265))
     return kVideoCodecH265;
 #endif

--- a/api/video_codecs/video_codec.h
+++ b/api/video_codecs/video_codec.h
@@ -97,7 +97,6 @@ struct VideoCodecH264 {
   uint8_t numberOfTemporalLayers;
 };
 
-#ifndef DISABLE_H265
 struct VideoCodecH265 {
   bool operator==(const VideoCodecH265& other) const;
   bool operator!=(const VideoCodecH265& other) const {
@@ -112,7 +111,6 @@ struct VideoCodecH265 {
   const uint8_t* ppsData;
   size_t ppsLen;
 };
-#endif
 
 // Translates from name of codec to codec type and vice versa.
 RTC_EXPORT const char* CodecTypeToPayloadString(VideoCodecType type);
@@ -122,9 +120,7 @@ union VideoCodecUnion {
   VideoCodecVP8 VP8;
   VideoCodecVP9 VP9;
   VideoCodecH264 H264;
-#ifndef DISABLE_H265
   VideoCodecH265 H265;
-#endif
 };
 
 enum class VideoCodecMode { kRealtimeVideo, kScreensharing };
@@ -204,10 +200,8 @@ class RTC_EXPORT VideoCodec {
   const VideoCodecVP9& VP9() const;
   VideoCodecH264* H264();
   const VideoCodecH264& H264() const;
-#ifndef DISABLE_H265
   VideoCodecH265* H265();
   const VideoCodecH265& H265() const;
-#endif
 
  private:
   // TODO(hta): Consider replacing the union with a pointer type.

--- a/api/video_codecs/video_decoder_software_fallback_wrapper.cc
+++ b/api/video_codecs/video_decoder_software_fallback_wrapper.cc
@@ -167,12 +167,10 @@ void VideoDecoderSoftwareFallbackWrapper::UpdateFallbackDecoderHistograms() {
       RTC_HISTOGRAM_COUNTS_100000(kFallbackHistogramsUmaPrefix + "H264",
                                   hw_decoded_frames_since_last_fallback_);
       break;
-#ifndef DISABLE_H265
     case kVideoCodecH265:
       RTC_HISTOGRAM_COUNTS_100000(kFallbackHistogramsUmaPrefix + "H265",
                                   hw_decoded_frames_since_last_fallback_);
       break;
-#endif
     case kVideoCodecMultiplex:
       RTC_HISTOGRAM_COUNTS_100000(kFallbackHistogramsUmaPrefix + "Multiplex",
                                   hw_decoded_frames_since_last_fallback_);

--- a/api/video_codecs/video_encoder.cc
+++ b/api/video_codecs/video_encoder.cc
@@ -57,7 +57,7 @@ VideoCodecH264 VideoEncoder::GetDefaultH264Settings() {
   return h264_settings;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 VideoCodecH265 VideoEncoder::GetDefaultH265Settings() {
   VideoCodecH265 h265_settings;
   memset(&h265_settings, 0, sizeof(h265_settings));

--- a/api/video_codecs/video_encoder.h
+++ b/api/video_codecs/video_encoder.h
@@ -335,7 +335,7 @@ class RTC_EXPORT VideoEncoder {
   static VideoCodecVP8 GetDefaultVp8Settings();
   static VideoCodecVP9 GetDefaultVp9Settings();
   static VideoCodecH264 GetDefaultH264Settings();
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   static VideoCodecH265 GetDefaultH265Settings();
 #endif
 

--- a/call/rtp_payload_params.cc
+++ b/call/rtp_payload_params.cc
@@ -98,7 +98,7 @@ void PopulateRtpWithCodecSpecifics(const CodecSpecificInfo& info,
       rtp->simulcastIdx = spatial_index.value_or(0);
       return;
     }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265: {
       auto& h265_header = rtp->video_type_header.emplace<RTPVideoHeaderH265>();
       h265_header.packetization_mode =
@@ -349,9 +349,7 @@ void RtpPayloadParams::SetGeneric(const CodecSpecificInfo* codec_specific_info,
                       is_keyframe, rtp_video_header);
       }
       return;
-#ifndef DISABLE_H265
     case VideoCodecType::kVideoCodecH265:
-#endif
     case VideoCodecType::kVideoCodecMultiplex:
       return;
   }
@@ -415,6 +413,7 @@ absl::optional<FrameDependencyStructure> RtpPayloadParams::GenericStructure(
     }
     case VideoCodecType::kVideoCodecAV1:
     case VideoCodecType::kVideoCodecH264:
+    case VideoCodecType::kVideoCodecH265:
     case VideoCodecType::kVideoCodecMultiplex:
       return absl::nullopt;
   }

--- a/common_video/BUILD.gn
+++ b/common_video/BUILD.gn
@@ -23,12 +23,20 @@ rtc_library("common_video") {
     "h264/h264_common.h",
     "h264/pps_parser.cc",
     "h264/pps_parser.h",
-    # "h264/prefix_parser.cc",
-    # "h264/prefix_parser.h",
     "h264/sps_parser.cc",
     "h264/sps_parser.h",
     "h264/sps_vui_rewriter.cc",
     "h264/sps_vui_rewriter.h",
+    "h265/h265_bitstream_parser.cc",
+    "h265/h265_bitstream_parser.h",
+    "h265/h265_common.cc",
+    "h265/h265_common.h",
+    "h265/h265_pps_parser.cc",
+    "h265/h265_pps_parser.h",
+    "h265/h265_sps_parser.cc",
+    "h265/h265_sps_parser.h",
+    "h265/h265_vps_parser.cc",
+    "h265/h265_vps_parser.h",
     "include/bitrate_adjuster.h",
     "include/quality_limitation_reason.h",
     "include/video_frame_buffer.h",
@@ -38,21 +46,6 @@ rtc_library("common_video") {
     "video_frame_buffer.cc",
     "video_frame_buffer_pool.cc",
   ]
-
-  if (rtc_use_h265) {
-    sources += [
-      "h265/h265_bitstream_parser.cc",
-      "h265/h265_bitstream_parser.h",
-      "h265/h265_common.cc",
-      "h265/h265_common.h",
-      "h265/h265_pps_parser.cc",
-      "h265/h265_pps_parser.h",
-      "h265/h265_sps_parser.cc",
-      "h265/h265_sps_parser.h",
-      "h265/h265_vps_parser.cc",
-      "h265/h265_vps_parser.h",
-    ]
-  }
 
   deps = [
     "../api:array_view",

--- a/common_video/h265/h265_bitstream_parser.h
+++ b/common_video/h265/h265_bitstream_parser.h
@@ -50,13 +50,14 @@ class H265BitstreamParser : public BitstreamParser {
                                   size_t source_length,
                                   uint8_t nalu_type);
 
-  uint32_t CalcNumPocTotalCurr(uint32_t num_long_term_sps,
-                               uint32_t num_long_term_pics,
-                               const std::vector<uint32_t> lt_idx_sps,
-                               const std::vector<uint32_t> used_by_curr_pic_lt_flag,
-                               uint32_t short_term_ref_pic_set_sps_flag,
-                               uint32_t short_term_ref_pic_set_idx,
-                               const H265SpsParser::ShortTermRefPicSet& short_term_ref_pic_set);
+  uint32_t CalcNumPocTotalCurr(
+      uint32_t num_long_term_sps,
+      uint32_t num_long_term_pics,
+      const std::vector<uint32_t> lt_idx_sps,
+      const std::vector<bool> used_by_curr_pic_lt_flag,
+      bool short_term_ref_pic_set_sps_flag,
+      uint32_t short_term_ref_pic_set_idx,
+      const H265SpsParser::ShortTermRefPicSet& short_term_ref_pic_set);
 
   // SPS/PPS state, updated when parsing new SPS/PPS, used to parse slices.
   absl::optional<H265SpsParser::SpsState> sps_;

--- a/common_video/h265/h265_pps_parser.cc
+++ b/common_video/h265/h265_pps_parser.cc
@@ -13,14 +13,16 @@
 #include <memory>
 #include <vector>
 
+#include "absl/types/optional.h"
 #include "common_video/h265/h265_common.h"
 #include "common_video/h265/h265_sps_parser.h"
 #include "rtc_base/bit_buffer.h"
+#include "rtc_base/bitstream_reader.h"
 #include "rtc_base/logging.h"
 
 #define RETURN_EMPTY_ON_FAIL(x) \
   if (!(x)) {                   \
-    return absl::nullopt;        \
+    return absl::nullopt;       \
   }
 
 namespace {
@@ -40,9 +42,7 @@ absl::optional<H265PpsParser::PpsState> H265PpsParser::ParsePps(
   // First, parse out rbsp, which is basically the source buffer minus emulation
   // bytes (the last byte of a 0x00 0x00 0x03 sequence). RBSP is defined in
   // section 7.3.1.1 of the H.265 standard.
-  std::vector<uint8_t> unpacked_buffer = H265::ParseRbsp(data, length);
-  rtc::BitBuffer bit_buffer(unpacked_buffer.data(), unpacked_buffer.size());
-  return ParseInternal(&bit_buffer);
+  return ParseInternal(H265::ParseRbsp(data, length));
 }
 
 bool H265PpsParser::ParsePpsIds(const uint8_t* data,
@@ -55,161 +55,166 @@ bool H265PpsParser::ParsePpsIds(const uint8_t* data,
   // bytes (the last byte of a 0x00 0x00 0x03 sequence). RBSP is defined in
   // section 7.3.1.1 of the H.265 standard.
   std::vector<uint8_t> unpacked_buffer = H265::ParseRbsp(data, length);
-  rtc::BitBuffer bit_buffer(unpacked_buffer.data(), unpacked_buffer.size());
-  return ParsePpsIdsInternal(&bit_buffer, pps_id, sps_id);
+  BitstreamReader reader(unpacked_buffer);
+  *pps_id = reader.ReadExponentialGolomb();
+  *sps_id = reader.ReadExponentialGolomb();
+  return reader.Ok();
 }
 
 absl::optional<uint32_t> H265PpsParser::ParsePpsIdFromSliceSegmentLayerRbsp(
     const uint8_t* data,
     size_t length,
     uint8_t nalu_type) {
-  rtc::BitBuffer slice_reader(data, length);
+  std::vector<uint8_t> unpacked_buffer = H265::ParseRbsp(data, length);
+  BitstreamReader slice_reader(unpacked_buffer);
+
+  // first_mb_in_slice: ue(v)
+  slice_reader.ReadExponentialGolomb();
+  // slice_type: ue(v)
+  slice_reader.ReadExponentialGolomb();
 
   // first_slice_segment_in_pic_flag: u(1)
-  uint32_t first_slice_segment_in_pic_flag = 0;
-  RETURN_EMPTY_ON_FAIL(
-      slice_reader.ReadBits(&first_slice_segment_in_pic_flag, 1));
+  slice_reader.ConsumeBits(1);
+  if (!slice_reader.Ok()) {
+    return absl::nullopt;
+  }
 
   if (nalu_type >= H265::NaluType::kBlaWLp &&
       nalu_type <= H265::NaluType::kRsvIrapVcl23) {
     // no_output_of_prior_pics_flag: u(1)
-    RETURN_EMPTY_ON_FAIL(slice_reader.ConsumeBits(1));
+    slice_reader.ConsumeBits(1);
   }
 
   // slice_pic_parameter_set_id: ue(v)
-  uint32_t slice_pic_parameter_set_id = 0;
-  if (!slice_reader.ReadExponentialGolomb(&slice_pic_parameter_set_id))
+  uint32_t slice_pic_parameter_set_id = slice_reader.ReadExponentialGolomb();
+  if (!slice_reader.Ok()) {
     return absl::nullopt;
+  }
 
   return slice_pic_parameter_set_id;
 }
 
 absl::optional<H265PpsParser::PpsState> H265PpsParser::ParseInternal(
-    rtc::BitBuffer* bit_buffer) {
+    rtc::ArrayView<const uint8_t> buffer) {
+  BitstreamReader reader(buffer);
   PpsState pps;
 
-  RETURN_EMPTY_ON_FAIL(ParsePpsIdsInternal(bit_buffer, &pps.id, &pps.sps_id));
+  if(!ParsePpsIdsInternal(reader, pps.id, pps.sps_id)){
+    return absl::nullopt;
+  }
 
-  uint32_t bits_tmp;
-  uint32_t golomb_ignored;
-  int32_t signed_golomb_ignored;
   // dependent_slice_segments_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.dependent_slice_segments_enabled_flag, 1));
+  pps.dependent_slice_segments_enabled_flag = reader.Read<bool>();
   // output_flag_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.output_flag_present_flag, 1));
+  pps.output_flag_present_flag = reader.Read<bool>();
   // num_extra_slice_header_bits: u(3)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.num_extra_slice_header_bits, 3));
+  pps.num_extra_slice_header_bits = reader.ReadBits(3);
   // sign_data_hiding_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // cabac_init_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.cabac_init_present_flag, 1));
+  pps.cabac_init_present_flag = reader.Read<bool>();
   // num_ref_idx_l0_default_active_minus1: ue(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&pps.num_ref_idx_l0_default_active_minus1));
+  pps.num_ref_idx_l0_default_active_minus1 = reader.ReadExponentialGolomb();
   // num_ref_idx_l1_default_active_minus1: ue(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&pps.num_ref_idx_l1_default_active_minus1));
+  pps.num_ref_idx_l1_default_active_minus1 = reader.ReadExponentialGolomb();
   // init_qp_minus26: se(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadSignedExponentialGolomb(&pps.pic_init_qp_minus26));
+  pps.pic_init_qp_minus26 = reader.ReadSignedExponentialGolomb();
   // Sanity-check parsed value
   if (pps.pic_init_qp_minus26 > kMaxPicInitQpDeltaValue ||
       pps.pic_init_qp_minus26 < kMinPicInitQpDeltaValue) {
-    RETURN_EMPTY_ON_FAIL(false);
+    return absl::nullopt;
   }
   // constrained_intra_pred_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // transform_skip_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // cu_qp_delta_enabled_flag: u(1)
-  uint32_t cu_qp_delta_enabled_flag = 0;
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&cu_qp_delta_enabled_flag, 1));
+  bool cu_qp_delta_enabled_flag = reader.Read<bool>();
   if (cu_qp_delta_enabled_flag) {
     // diff_cu_qp_delta_depth: ue(v)
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&golomb_ignored));
+    reader.ReadExponentialGolomb();
   }
   // pps_cb_qp_offset: se(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadSignedExponentialGolomb(&signed_golomb_ignored));
+  reader.ReadSignedExponentialGolomb();
   // pps_cr_qp_offset: se(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadSignedExponentialGolomb(&signed_golomb_ignored));
+  reader.ReadSignedExponentialGolomb();
   // pps_slice_chroma_qp_offsets_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // weighted_pred_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.weighted_pred_flag, 1));
+  pps.weighted_pred_flag = reader.Read<bool>();
   // weighted_bipred_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.weighted_bipred_flag, 1));
+  pps.weighted_bipred_flag = reader.Read<bool>();
   // transquant_bypass_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // tiles_enabled_flag: u(1)
-  uint32_t tiles_enabled_flag = 0;
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&tiles_enabled_flag, 1));
+  bool tiles_enabled_flag = reader.Read<bool>();
   // entropy_coding_sync_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   if (tiles_enabled_flag) {
     // num_tile_columns_minus1: ue(v)
-    uint32_t num_tile_columns_minus1 = 0;
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&num_tile_columns_minus1));
+    uint32_t num_tile_columns_minus1 = reader.ReadExponentialGolomb();
     // num_tile_rows_minus1: ue(v)
-    uint32_t num_tile_rows_minus1 = 0;
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&num_tile_rows_minus1));
+    uint32_t num_tile_rows_minus1 = reader.ReadExponentialGolomb();
     // uniform_spacing_flag: u(1)
-    uint32_t uniform_spacing_flag = 0;
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&uniform_spacing_flag, 1));
+    bool uniform_spacing_flag = reader.Read<bool>();
     if (!uniform_spacing_flag) {
       for (uint32_t i = 0; i < num_tile_columns_minus1; i++) {
         // column_width_minus1: ue(v)
-        RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&golomb_ignored));
+        reader.ReadExponentialGolomb();
       }
       for (uint32_t i = 0; i < num_tile_rows_minus1; i++) {
         // row_height_minus1: ue(v)
-        RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&golomb_ignored));
+        reader.ReadExponentialGolomb();
       }
       // loop_filter_across_tiles_enabled_flag: u(1)
-      RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+      reader.ConsumeBits(1);
     }
   }
   // pps_loop_filter_across_slices_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
   // deblocking_filter_control_present_flag: u(1)
-  uint32_t deblocking_filter_control_present_flag = 0;
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&deblocking_filter_control_present_flag, 1));
+  bool deblocking_filter_control_present_flag = reader.Read<bool>();
   if (deblocking_filter_control_present_flag) {
     // deblocking_filter_override_enabled_flag: u(1)
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+    reader.ConsumeBits(1);
     // pps_deblocking_filter_disabled_flag: u(1)
-    uint32_t pps_deblocking_filter_disabled_flag = 0;
-    RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps_deblocking_filter_disabled_flag, 1));
+    bool pps_deblocking_filter_disabled_flag = reader.Read<bool>();
     if (!pps_deblocking_filter_disabled_flag) {
       // pps_beta_offset_div2: se(v)
-      RETURN_EMPTY_ON_FAIL(bit_buffer->ReadSignedExponentialGolomb(&signed_golomb_ignored));
+      reader.ReadSignedExponentialGolomb();
       // pps_tc_offset_div2: se(v)
-      RETURN_EMPTY_ON_FAIL(bit_buffer->ReadSignedExponentialGolomb(&signed_golomb_ignored));
+      reader.ReadSignedExponentialGolomb();
     }
   }
   // pps_scaling_list_data_present_flag: u(1)
-  uint32_t pps_scaling_list_data_present_flag = 0;
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps_scaling_list_data_present_flag, 1));
+  bool pps_scaling_list_data_present_flag = 0;
+  pps_scaling_list_data_present_flag = reader.Read<bool>();
   if (pps_scaling_list_data_present_flag) {
     // scaling_list_data()
-    if (!H265SpsParser::ParseScalingListData(bit_buffer)) {
+    if (!H265SpsParser::ParseScalingListData(reader)) {
       return absl::nullopt;
     }
   }
   // lists_modification_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&pps.lists_modification_present_flag, 1));
+  pps.lists_modification_present_flag = reader.Read<bool>();
   // log2_parallel_merge_level_minus2: ue(v)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // slice_segment_header_extension_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(bit_buffer->ReadBits(&bits_tmp, 1));
+  reader.ConsumeBits(1);
 
   return pps;
 }
 
-bool H265PpsParser::ParsePpsIdsInternal(rtc::BitBuffer* bit_buffer,
-                                        uint32_t* pps_id,
-                                        uint32_t* sps_id) {
+bool H265PpsParser::ParsePpsIdsInternal(BitstreamReader& reader,
+                                        uint32_t& pps_id,
+                                        uint32_t& sps_id) {
   // pic_parameter_set_id: ue(v)
-  if (!bit_buffer->ReadExponentialGolomb(pps_id))
+  pps_id = reader.ReadExponentialGolomb();
+  if (!reader.Ok())
     return false;
   // seq_parameter_set_id: ue(v)
-  if (!bit_buffer->ReadExponentialGolomb(sps_id))
+  sps_id = reader.ReadExponentialGolomb();
+  if (!reader.Ok())
     return false;
   return true;
 }

--- a/common_video/h265/h265_pps_parser.h
+++ b/common_video/h265/h265_pps_parser.h
@@ -12,6 +12,8 @@
 #define COMMON_VIDEO_H265_PPS_PARSER_H_
 
 #include "absl/types/optional.h"
+#include "api/array_view.h"
+#include "rtc_base/bitstream_reader.h"
 
 namespace rtc {
 class BitBuffer;
@@ -27,16 +29,16 @@ class H265PpsParser {
   struct PpsState {
     PpsState() = default;
 
-    uint32_t dependent_slice_segments_enabled_flag = 0;
-    uint32_t cabac_init_present_flag = 0;
-    uint32_t output_flag_present_flag = 0;
+    bool dependent_slice_segments_enabled_flag = 0;
+    bool cabac_init_present_flag = 0;
+    bool output_flag_present_flag = 0;
     uint32_t num_extra_slice_header_bits = 0;
     uint32_t num_ref_idx_l0_default_active_minus1 = 0;
     uint32_t num_ref_idx_l1_default_active_minus1 = 0;
     int32_t pic_init_qp_minus26 = 0;
-    uint32_t weighted_pred_flag = 0;
-    uint32_t weighted_bipred_flag = 0;
-    uint32_t lists_modification_present_flag = 0;
+    bool weighted_pred_flag = 0;
+    bool weighted_bipred_flag = 0;
+    bool lists_modification_present_flag = 0;
     uint32_t id = 0;
     uint32_t sps_id = 0;
   };
@@ -57,10 +59,11 @@ class H265PpsParser {
  protected:
   // Parse the PPS state, for a bit buffer where RBSP decoding has already been
   // performed.
-  static absl::optional<PpsState> ParseInternal(rtc::BitBuffer* bit_buffer);
-  static bool ParsePpsIdsInternal(rtc::BitBuffer* bit_buffer,
-                                  uint32_t* pps_id,
-                                  uint32_t* sps_id);
+  static absl::optional<PpsState> ParseInternal(
+      rtc::ArrayView<const uint8_t> buffer);
+  static bool ParsePpsIdsInternal(BitstreamReader& reader,
+                                  uint32_t& pps_id,
+                                  uint32_t& sps_id);
 };
 
 }  // namespace webrtc

--- a/common_video/h265/h265_sps_parser.cc
+++ b/common_video/h265/h265_sps_parser.cc
@@ -8,32 +8,19 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+#include "common_video/h265/h265_sps_parser.h"
+
 #include <memory>
 #include <vector>
 
 #include "common_video/h265/h265_common.h"
-#include "common_video/h265/h265_sps_parser.h"
 #include "rtc_base/bit_buffer.h"
 #include "rtc_base/logging.h"
 
 namespace {
 typedef absl::optional<webrtc::H265SpsParser::SpsState> OptionalSps;
-typedef absl::optional<webrtc::H265SpsParser::ShortTermRefPicSet> OptionalShortTermRefPicSet;
-
-#define RETURN_EMPTY_ON_FAIL(x) \
-  if (!(x)) {                   \
-    return OptionalSps();       \
-  }
-
-#define RETURN_FALSE_ON_FAIL(x) \
-  if (!(x)) {                   \
-    return false;               \
-  }
-
-#define RETURN_EMPTY2_ON_FAIL(x)                \
-  if (!(x)) {                                   \
-    return OptionalShortTermRefPicSet();        \
-  }
+typedef absl::optional<webrtc::H265SpsParser::ShortTermRefPicSet>
+    OptionalShortTermRefPicSet;
 }  // namespace
 
 namespace webrtc {
@@ -50,35 +37,36 @@ H265SpsParser::ShortTermRefPicSet::ShortTermRefPicSet() = default;
 absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSps(
     const uint8_t* data,
     size_t length) {
-  std::vector<uint8_t> unpacked_buffer = H265::ParseRbsp(data, length);
-  rtc::BitBuffer bit_buffer(unpacked_buffer.data(), unpacked_buffer.size());
-  return ParseSpsInternal(&bit_buffer);
+  return ParseSpsInternal(H265::ParseRbsp(data, length));
 }
 
-bool H265SpsParser::ParseScalingListData(rtc::BitBuffer* buffer) {
+bool H265SpsParser::ParseScalingListData(BitstreamReader& reader) {
   uint32_t scaling_list_pred_mode_flag[4][6];
   uint32_t scaling_list_pred_matrix_id_delta[4][6];
   int32_t scaling_list_dc_coef_minus8[4][6];
   int32_t scaling_list[4][6][64];
   for (int size_id = 0; size_id < 4; size_id++) {
-    for (int matrix_id = 0; matrix_id < 6; matrix_id += (size_id == 3) ? 3 : 1) {
+    for (int matrix_id = 0; matrix_id < 6;
+         matrix_id += (size_id == 3) ? 3 : 1) {
       // scaling_list_pred_mode_flag: u(1)
-      RETURN_FALSE_ON_FAIL(buffer->ReadBits(&scaling_list_pred_mode_flag[size_id][matrix_id], 1));
+      scaling_list_pred_mode_flag[size_id][matrix_id] = reader.Read<bool>();
       if (!scaling_list_pred_mode_flag[size_id][matrix_id]) {
         // scaling_list_pred_matrix_id_delta: ue(v)
-        RETURN_FALSE_ON_FAIL(buffer->ReadExponentialGolomb(&scaling_list_pred_matrix_id_delta[size_id][matrix_id]));
+        scaling_list_pred_matrix_id_delta[size_id][matrix_id] =
+            reader.ReadExponentialGolomb();
       } else {
         int32_t next_coef = 8;
         uint32_t coef_num = std::min(64, 1 << (4 + (size_id << 1)));
         if (size_id > 1) {
           // scaling_list_dc_coef_minus8: se(v)
-          RETURN_FALSE_ON_FAIL(buffer->ReadSignedExponentialGolomb(&scaling_list_dc_coef_minus8[size_id - 2][matrix_id]));
+          scaling_list_dc_coef_minus8[size_id - 2][matrix_id] =
+              reader.ReadSignedExponentialGolomb();
           next_coef = scaling_list_dc_coef_minus8[size_id - 2][matrix_id];
         }
         for (uint32_t i = 0; i < coef_num; i++) {
           // scaling_list_delta_coef: se(v)
-          int32_t scaling_list_delta_coef = 0;
-          RETURN_FALSE_ON_FAIL(buffer->ReadSignedExponentialGolomb(&scaling_list_delta_coef));
+          int32_t scaling_list_delta_coef =
+              reader.ReadSignedExponentialGolomb();
           next_coef = (next_coef + scaling_list_delta_coef + 256) % 256;
           scaling_list[size_id][matrix_id][i] = next_coef;
         }
@@ -88,33 +76,36 @@ bool H265SpsParser::ParseScalingListData(rtc::BitBuffer* buffer) {
   return true;
 }
 
-absl::optional<H265SpsParser::ShortTermRefPicSet> H265SpsParser::ParseShortTermRefPicSet(
-        uint32_t st_rps_idx, uint32_t num_short_term_ref_pic_sets,
-        const std::vector<H265SpsParser::ShortTermRefPicSet>& short_term_ref_pic_set,
-        H265SpsParser::SpsState& sps, rtc::BitBuffer* buffer) {
+absl::optional<H265SpsParser::ShortTermRefPicSet>
+H265SpsParser::ParseShortTermRefPicSet(
+    uint32_t st_rps_idx,
+    uint32_t num_short_term_ref_pic_sets,
+    const std::vector<H265SpsParser::ShortTermRefPicSet>&
+        short_term_ref_pic_set,
+    H265SpsParser::SpsState& sps,
+    BitstreamReader& reader) {
   H265SpsParser::ShortTermRefPicSet ref_pic_set;
 
-  uint32_t inter_ref_pic_set_prediction_flag = 0;
+  bool inter_ref_pic_set_prediction_flag = false;
   if (st_rps_idx != 0) {
     // inter_ref_pic_set_prediction_flag: u(1)
-    RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&inter_ref_pic_set_prediction_flag, 1));
+    inter_ref_pic_set_prediction_flag = reader.Read<bool>();
   }
   if (inter_ref_pic_set_prediction_flag) {
     uint32_t delta_idx_minus1 = 0;
     if (st_rps_idx == num_short_term_ref_pic_sets) {
       // delta_idx_minus1: ue(v)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&delta_idx_minus1));
+      delta_idx_minus1 = reader.ReadExponentialGolomb();
     }
     // delta_rps_sign: u(1)
-    uint32_t delta_rps_sign = 0;
-    RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&delta_rps_sign, 1));
+    reader.ConsumeBits(1);
     // abs_delta_rps_minus1: ue(v)
-    uint32_t abs_delta_rps_minus1 = 0;
-    RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&abs_delta_rps_minus1));
+    reader.ReadExponentialGolomb();
     uint32_t ref_rps_idx = st_rps_idx - (delta_idx_minus1 + 1);
     uint32_t num_delta_pocs = 0;
     if (short_term_ref_pic_set[ref_rps_idx].inter_ref_pic_set_prediction_flag) {
-      auto& used_by_curr_pic_flag = short_term_ref_pic_set[ref_rps_idx].used_by_curr_pic_flag;
+      auto& used_by_curr_pic_flag =
+          short_term_ref_pic_set[ref_rps_idx].used_by_curr_pic_flag;
       auto& use_delta_flag = short_term_ref_pic_set[ref_rps_idx].use_delta_flag;
       if (used_by_curr_pic_flag.size() != use_delta_flag.size()) {
         return OptionalShortTermRefPicSet();
@@ -125,39 +116,42 @@ absl::optional<H265SpsParser::ShortTermRefPicSet> H265SpsParser::ParseShortTermR
         }
       }
     } else {
-      num_delta_pocs = short_term_ref_pic_set[ref_rps_idx].num_negative_pics + short_term_ref_pic_set[ref_rps_idx].num_positive_pics;
+      num_delta_pocs = short_term_ref_pic_set[ref_rps_idx].num_negative_pics +
+                       short_term_ref_pic_set[ref_rps_idx].num_positive_pics;
     }
     ref_pic_set.used_by_curr_pic_flag.resize(num_delta_pocs + 1, 0);
     ref_pic_set.use_delta_flag.resize(num_delta_pocs + 1, 1);
     for (uint32_t j = 0; j <= num_delta_pocs; j++) {
       // used_by_curr_pic_flag: u(1)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&ref_pic_set.used_by_curr_pic_flag[j], 1));
+      ref_pic_set.used_by_curr_pic_flag[j] = reader.Read<bool>();
       if (!ref_pic_set.used_by_curr_pic_flag[j]) {
         // use_delta_flag: u(1)
-        RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&ref_pic_set.use_delta_flag[j], 1));
+        ref_pic_set.use_delta_flag[j] = reader.Read<bool>();
       }
     }
   } else {
     // num_negative_pics: ue(v)
-    RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&ref_pic_set.num_negative_pics));
+    ref_pic_set.num_negative_pics = reader.ReadExponentialGolomb();
     // num_positive_pics: ue(v)
-    RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&ref_pic_set.num_positive_pics));
+    ref_pic_set.num_positive_pics = reader.ReadExponentialGolomb();
 
     ref_pic_set.delta_poc_s0_minus1.resize(ref_pic_set.num_negative_pics, 0);
-    ref_pic_set.used_by_curr_pic_s0_flag.resize(ref_pic_set.num_negative_pics, 0);
+    ref_pic_set.used_by_curr_pic_s0_flag.resize(ref_pic_set.num_negative_pics,
+                                                0);
     for (uint32_t i = 0; i < ref_pic_set.num_negative_pics; i++) {
       // delta_poc_s0_minus1: ue(v)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&ref_pic_set.delta_poc_s0_minus1[i]));
+      ref_pic_set.delta_poc_s0_minus1[i] = reader.ReadExponentialGolomb();
       // used_by_curr_pic_s0_flag: u(1)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&ref_pic_set.used_by_curr_pic_s0_flag[i], 1));
+      ref_pic_set.used_by_curr_pic_s0_flag[i] = reader.Read<bool>();
     }
     ref_pic_set.delta_poc_s1_minus1.resize(ref_pic_set.num_positive_pics, 0);
-    ref_pic_set.used_by_curr_pic_s1_flag.resize(ref_pic_set.num_positive_pics, 0);
+    ref_pic_set.used_by_curr_pic_s1_flag.resize(ref_pic_set.num_positive_pics,
+                                                0);
     for (uint32_t i = 0; i < ref_pic_set.num_positive_pics; i++) {
       // delta_poc_s1_minus1: ue(v)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadExponentialGolomb(&ref_pic_set.delta_poc_s1_minus1[i]));
+      ref_pic_set.delta_poc_s1_minus1[i] = reader.ReadExponentialGolomb();
       // used_by_curr_pic_s1_flag: u(1)
-      RETURN_EMPTY2_ON_FAIL(buffer->ReadBits(&ref_pic_set.used_by_curr_pic_s1_flag[i], 1));
+      ref_pic_set.used_by_curr_pic_s1_flag[i] = reader.Read<bool>();
     }
   }
 
@@ -165,7 +159,9 @@ absl::optional<H265SpsParser::ShortTermRefPicSet> H265SpsParser::ParseShortTermR
 }
 
 absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
-    rtc::BitBuffer* buffer) {
+    rtc::ArrayView<const uint8_t> buffer) {
+  BitstreamReader reader(buffer);
+
   // Now, we need to use a bit buffer to parse through the actual HEVC SPS
   // format. See Section 7.3.2.2.1 ("General sequence parameter set data
   // syntax") of the H.265 standard for a complete description.
@@ -176,37 +172,33 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   // chroma_format_idc -> affects crop units
   // pic_{width,height}_* -> resolution of the frame in macroblocks (16x16).
   // frame_crop_*_offset -> crop information
-
   SpsState sps;
-
-  // The golomb values we have to read, not just consume.
-  uint32_t golomb_ignored;
 
   // sps_video_parameter_set_id: u(4)
   uint32_t sps_video_parameter_set_id = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps_video_parameter_set_id, 4));
+  sps_video_parameter_set_id = reader.ReadBits(4);
   // sps_max_sub_layers_minus1: u(3)
   uint32_t sps_max_sub_layers_minus1 = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps_max_sub_layers_minus1, 3));
+  sps_max_sub_layers_minus1 = reader.ReadBits(3);
   sps.sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
   sps.sps_max_dec_pic_buffering_minus1.resize(sps_max_sub_layers_minus1 + 1, 0);
   // sps_temporal_id_nesting_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(1));
+  reader.ConsumeBits(1);
   // profile_tier_level(1, sps_max_sub_layers_minus1). We are acutally not
   // using them, so read/skip over it.
   // general_profile_space+general_tier_flag+general_prfile_idc: u(8)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(1));
+  reader.ConsumeBits(8);
   // general_profile_compatabilitiy_flag[32]
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(4));
+  reader.ConsumeBits(32);
   // general_progressive_source_flag + interlaced_source_flag+
   // non-packed_constraint flag + frame_only_constraint_flag: u(4)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(4));
+  reader.ConsumeBits(4);
   // general_profile_idc decided flags or reserved.  u(43)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(43));
+  reader.ConsumeBits(43);
   // general_inbld_flag or reserved 0: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(1));
+  reader.ConsumeBits(1);
   // general_level_idc: u(8)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(1));
+  reader.ConsumeBits(8);
   // if max_sub_layers_minus1 >=1, read the sublayer profile information
   std::vector<uint32_t> sub_layer_profile_present_flags;
   std::vector<uint32_t> sub_layer_level_present_flags;
@@ -214,56 +206,53 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   uint32_t sub_layer_level_present = 0;
   for (uint32_t i = 0; i < sps_max_sub_layers_minus1; i++) {
     // sublayer_profile_present_flag and sublayer_level_presnet_flag:  u(2)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sub_layer_profile_present, 1));
-    RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sub_layer_level_present, 1));
+    sub_layer_profile_present = reader.Read<bool>();
+    sub_layer_level_present = reader.Read<bool>();
     sub_layer_profile_present_flags.push_back(sub_layer_profile_present);
     sub_layer_level_present_flags.push_back(sub_layer_level_present);
   }
   if (sps_max_sub_layers_minus1 > 0) {
     for (uint32_t j = sps_max_sub_layers_minus1; j < 8; j++) {
       // reserved 2 bits: u(2)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(2));
+      reader.ConsumeBits(2);
     }
   }
   for (uint32_t k = 0; k < sps_max_sub_layers_minus1; k++) {
     if (sub_layer_profile_present_flags[k]) {  //
       // sub_layer profile_space/tier_flag/profile_idc. ignored. u(8)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(1));
+      reader.ConsumeBits(8);
       // profile_compatability_flag:  u(32)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(4));
+      reader.ConsumeBits(32);
       // sub_layer progressive_source_flag/interlaced_source_flag/
       // non_packed_constraint_flag/frame_only_constraint_flag: u(4)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(4));
+      reader.ConsumeBits(4);
       // following 43-bits are profile_idc specific. We simply read/skip it.
       // u(43)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(43));
+      reader.ConsumeBits(43);
       // 1-bit profile_idc specific inbld flag.  We simply read/skip it. u(1)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(1));
+      reader.ConsumeBits(1);
     }
     if (sub_layer_level_present_flags[k]) {
       // sub_layer_level_idc: u(8)
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBytes(1));
+      reader.ConsumeBits(8);
     }
   }
   // sps_seq_parameter_set_id: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.id));
+  sps.id = reader.ReadExponentialGolomb();
   // chrome_format_idc: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.chroma_format_idc));
+  sps.chroma_format_idc = reader.ReadExponentialGolomb();
   if (sps.chroma_format_idc == 3) {
     // seperate_colour_plane_flag: u(1)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps.separate_colour_plane_flag, 1));
+    sps.separate_colour_plane_flag = reader.Read<bool>();
   }
   uint32_t pic_width_in_luma_samples = 0;
   uint32_t pic_height_in_luma_samples = 0;
   // pic_width_in_luma_samples: ue(v)
-  RETURN_EMPTY_ON_FAIL(
-      buffer->ReadExponentialGolomb(&pic_width_in_luma_samples));
+  pic_width_in_luma_samples = reader.ReadExponentialGolomb();
   // pic_height_in_luma_samples: ue(v)
-  RETURN_EMPTY_ON_FAIL(
-      buffer->ReadExponentialGolomb(&pic_height_in_luma_samples));
+  pic_height_in_luma_samples = reader.ReadExponentialGolomb();
   // conformance_window_flag: u(1)
-  uint32_t conformance_window_flag = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&conformance_window_flag, 1));
+  bool conformance_window_flag = reader.Read<bool>();
 
   uint32_t conf_win_left_offset = 0;
   uint32_t conf_win_right_offset = 0;
@@ -271,88 +260,88 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   uint32_t conf_win_bottom_offset = 0;
   if (conformance_window_flag) {
     // conf_win_left_offset: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&conf_win_left_offset));
+    conf_win_left_offset = reader.ReadExponentialGolomb();
     // conf_win_right_offset: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&conf_win_right_offset));
+    conf_win_right_offset = reader.ReadExponentialGolomb();
     // conf_win_top_offset: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&conf_win_top_offset));
+    conf_win_top_offset = reader.ReadExponentialGolomb();
     // conf_win_bottom_offset: ue(v)
-    RETURN_EMPTY_ON_FAIL(
-        buffer->ReadExponentialGolomb(&conf_win_bottom_offset));
+    conf_win_bottom_offset = reader.ReadExponentialGolomb();
   }
 
   // bit_depth_luma_minus8: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // bit_depth_chroma_minus8: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // log2_max_pic_order_cnt_lsb_minus4: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.log2_max_pic_order_cnt_lsb_minus4));
+  sps.log2_max_pic_order_cnt_lsb_minus4 = reader.ReadExponentialGolomb();
   uint32_t sps_sub_layer_ordering_info_present_flag = 0;
   // sps_sub_layer_ordering_info_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps_sub_layer_ordering_info_present_flag, 1));
-  for (uint32_t i = (sps_sub_layer_ordering_info_present_flag != 0) ? 0 : sps_max_sub_layers_minus1;
+  sps_sub_layer_ordering_info_present_flag = reader.Read<bool>();
+  for (uint32_t i = (sps_sub_layer_ordering_info_present_flag != 0)
+                        ? 0
+                        : sps_max_sub_layers_minus1;
        i <= sps_max_sub_layers_minus1; i++) {
     // sps_max_dec_pic_buffering_minus1: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.sps_max_dec_pic_buffering_minus1[i]));
+    sps.sps_max_dec_pic_buffering_minus1[i] = reader.ReadExponentialGolomb();
     // sps_max_num_reorder_pics: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+    reader.ReadExponentialGolomb();
     // sps_max_latency_increase_plus1: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+    reader.ReadExponentialGolomb();
   }
   // log2_min_luma_coding_block_size_minus3: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.log2_min_luma_coding_block_size_minus3));
+  sps.log2_min_luma_coding_block_size_minus3 = reader.ReadExponentialGolomb();
   // log2_diff_max_min_luma_coding_block_size: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.log2_diff_max_min_luma_coding_block_size));
+  sps.log2_diff_max_min_luma_coding_block_size = reader.ReadExponentialGolomb();
   // log2_min_luma_transform_block_size_minus2: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // log2_diff_max_min_luma_transform_block_size: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // max_transform_hierarchy_depth_inter: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // max_transform_hierarchy_depth_intra: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+  reader.ReadExponentialGolomb();
   // scaling_list_enabled_flag: u(1)
-  uint32_t scaling_list_enabled_flag = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&scaling_list_enabled_flag, 1));
+  bool scaling_list_enabled_flag = reader.Read<bool>();
   if (scaling_list_enabled_flag) {
     // sps_scaling_list_data_present_flag: u(1)
-    uint32_t sps_scaling_list_data_present_flag = 0;
-    RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps_scaling_list_data_present_flag, 1));
+    bool sps_scaling_list_data_present_flag = reader.Read<bool>();
     if (sps_scaling_list_data_present_flag) {
       // scaling_list_data()
-      if (!ParseScalingListData(buffer)) {
+      if (!ParseScalingListData(reader)) {
         return OptionalSps();
       }
     }
   }
 
   // amp_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(1));
+  reader.ConsumeBits(1);
   // sample_adaptive_offset_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps.sample_adaptive_offset_enabled_flag, 1));
+  sps.sample_adaptive_offset_enabled_flag = reader.Read<bool>();
   // pcm_enabled_flag: u(1)
-  uint32_t pcm_enabled_flag = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&pcm_enabled_flag, 1));
+  bool pcm_enabled_flag = reader.Read<bool>();
   if (pcm_enabled_flag) {
     // pcm_sample_bit_depth_luma_minus1: u(4)
-    RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(4));
+    reader.ConsumeBits(4);
     // pcm_sample_bit_depth_chroma_minus1: u(4)
-    RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(4));
+    reader.ConsumeBits(4);
     // log2_min_pcm_luma_coding_block_size_minus3: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+    reader.ReadExponentialGolomb();
     // log2_diff_max_min_pcm_luma_coding_block_size: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&golomb_ignored));
+    reader.ReadExponentialGolomb();
     // pcm_loop_filter_disabled_flag: u(1)
-    RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(1));
+    reader.ConsumeBits(1);
   }
 
   // num_short_term_ref_pic_sets: ue(v)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.num_short_term_ref_pic_sets));
+  sps.num_short_term_ref_pic_sets = reader.ReadExponentialGolomb();
   sps.short_term_ref_pic_set.resize(sps.num_short_term_ref_pic_sets);
-  for (uint32_t st_rps_idx = 0; st_rps_idx < sps.num_short_term_ref_pic_sets; st_rps_idx++) {
+  for (uint32_t st_rps_idx = 0; st_rps_idx < sps.num_short_term_ref_pic_sets;
+       st_rps_idx++) {
     // st_ref_pic_set()
-    OptionalShortTermRefPicSet ref_pic_set = ParseShortTermRefPicSet(
-        st_rps_idx, sps.num_short_term_ref_pic_sets, sps.short_term_ref_pic_set, sps, buffer);
+    OptionalShortTermRefPicSet ref_pic_set =
+        ParseShortTermRefPicSet(st_rps_idx, sps.num_short_term_ref_pic_sets,
+                                sps.short_term_ref_pic_set, sps, reader);
     if (ref_pic_set) {
       sps.short_term_ref_pic_set[st_rps_idx] = *ref_pic_set;
     } else {
@@ -361,22 +350,23 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   }
 
   // long_term_ref_pics_present_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps.long_term_ref_pics_present_flag, 1));
+  sps.long_term_ref_pics_present_flag = reader.Read<bool>();
   if (sps.long_term_ref_pics_present_flag) {
     // num_long_term_ref_pics_sps: ue(v)
-    RETURN_EMPTY_ON_FAIL(buffer->ReadExponentialGolomb(&sps.num_long_term_ref_pics_sps));
+    sps.num_long_term_ref_pics_sps = reader.ReadExponentialGolomb();
     sps.used_by_curr_pic_lt_sps_flag.resize(sps.num_long_term_ref_pics_sps, 0);
     for (uint32_t i = 0; i < sps.num_long_term_ref_pics_sps; i++) {
       // lt_ref_pic_poc_lsb_sps: u(v)
-      uint32_t lt_ref_pic_poc_lsb_sps_bits = sps.log2_max_pic_order_cnt_lsb_minus4 + 4;
-      RETURN_EMPTY_ON_FAIL(buffer->ConsumeBits(lt_ref_pic_poc_lsb_sps_bits));
+      uint32_t lt_ref_pic_poc_lsb_sps_bits =
+          sps.log2_max_pic_order_cnt_lsb_minus4 + 4;
+      reader.ConsumeBits(lt_ref_pic_poc_lsb_sps_bits);
       // used_by_curr_pic_lt_sps_flag: u(1)
-      RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps.used_by_curr_pic_lt_sps_flag[i], 1));
+      sps.used_by_curr_pic_lt_sps_flag[i] = reader.Read<bool>();
     }
   }
 
   // sps_temporal_mvp_enabled_flag: u(1)
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&sps.sps_temporal_mvp_enabled_flag, 1));
+  sps.sps_temporal_mvp_enabled_flag = reader.Read<bool>();
 
   // Far enough! We don't use the rest of the SPS.
 
@@ -390,12 +380,15 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   sps.height = pic_height_in_luma_samples;
 
   if (conformance_window_flag) {
-    int sub_width_c = ((1 == sps.chroma_format_idc) || (2 == sps.chroma_format_idc)) &&
-                              (0 == sps.separate_colour_plane_flag)
-                          ? 2
-                          : 1;
+    int sub_width_c =
+        ((1 == sps.chroma_format_idc) || (2 == sps.chroma_format_idc)) &&
+                (0 == sps.separate_colour_plane_flag)
+            ? 2
+            : 1;
     int sub_height_c =
-        (1 == sps.chroma_format_idc) && (0 == sps.separate_colour_plane_flag) ? 2 : 1;
+        (1 == sps.chroma_format_idc) && (0 == sps.separate_colour_plane_flag)
+            ? 2
+            : 1;
     // the offset includes the pixel within conformance window. so don't need to
     // +1 as per spec
     sps.width -= sub_width_c * (conf_win_right_offset + conf_win_left_offset);

--- a/common_video/h265/h265_sps_parser.h
+++ b/common_video/h265/h265_sps_parser.h
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include "absl/types/optional.h"
+#include "api/array_view.h"
+#include "rtc_base/bitstream_reader.h"
 
 namespace rtc {
 class BitBuffer;
@@ -69,17 +71,18 @@ class H265SpsParser {
   // Unpack RBSP and parse SPS state from the supplied buffer.
   static absl::optional<SpsState> ParseSps(const uint8_t* data, size_t length);
 
-  static bool ParseScalingListData(rtc::BitBuffer* buffer);
+  static bool ParseScalingListData(BitstreamReader& reader);
 
   static absl::optional<ShortTermRefPicSet> ParseShortTermRefPicSet(
         uint32_t st_rps_idx, uint32_t num_short_term_ref_pic_sets,
         const std::vector<ShortTermRefPicSet>& ref_pic_sets,
-        SpsState& sps, rtc::BitBuffer* buffer);
+        SpsState& sps, BitstreamReader& reader);
 
  protected:
  // Parse the SPS state, for a bit buffer where RBSP decoding has already been
  // performed.
-  static absl::optional<SpsState> ParseSpsInternal(rtc::BitBuffer* buffer);
+  static absl::optional<SpsState> ParseSpsInternal(
+      rtc::ArrayView<const uint8_t> buffer);
 };
 
 }  // namespace webrtc

--- a/common_video/h265/h265_vps_parser.cc
+++ b/common_video/h265/h265_vps_parser.cc
@@ -16,14 +16,7 @@
 #include "rtc_base/bit_buffer.h"
 #include "rtc_base/logging.h"
 
-namespace {
-typedef absl::optional<webrtc::H265VpsParser::VpsState> OptionalVps;
-
-#define RETURN_EMPTY_ON_FAIL(x) \
-  if (!(x)) {                   \
-    return OptionalVps();       \
-  }
-}  // namespace
+#include "rtc_base/bitstream_reader.h"
 
 namespace webrtc {
 
@@ -37,24 +30,22 @@ H265VpsParser::VpsState::VpsState() = default;
 absl::optional<H265VpsParser::VpsState> H265VpsParser::ParseVps(
     const uint8_t* data,
     size_t length) {
-  std::vector<uint8_t> unpacked_buffer = H265::ParseRbsp(data, length);
-  rtc::BitBuffer bit_buffer(unpacked_buffer.data(), unpacked_buffer.size());
-  return ParseInternal(&bit_buffer);
+  return ParseInternal(H265::ParseRbsp(data, length));
 }
 
 absl::optional<H265VpsParser::VpsState> H265VpsParser::ParseInternal(
-    rtc::BitBuffer* buffer) {
+    rtc::ArrayView<const uint8_t> buffer) {
+  BitstreamReader reader(buffer);
+
   // Now, we need to use a bit buffer to parse through the actual HEVC VPS
   // format. See Section 7.3.2.1 ("Video parameter set RBSP syntax") of the
   // H.265 standard for a complete description.
-
   VpsState vps;
 
   // vps_video_parameter_set_id: u(4)
-  vps.id = 0;
-  RETURN_EMPTY_ON_FAIL(buffer->ReadBits(&vps.id, 4));
+  vps.id = reader.Read<uint32_t>();
 
-  return OptionalVps(vps);
+  return vps;
 }
 
 }  // namespace webrtc

--- a/common_video/h265/h265_vps_parser.h
+++ b/common_video/h265/h265_vps_parser.h
@@ -12,6 +12,7 @@
 #define COMMON_VIDEO_H265_H265_VPS_PARSER_H_
 
 #include "absl/types/optional.h"
+#include "api/array_view.h"
 
 namespace rtc {
 class BitBuffer;
@@ -36,7 +37,8 @@ class H265VpsParser {
  protected:
   // Parse the VPS state, for a bit buffer where RBSP decoding has already been
   // performed.
-  static absl::optional<VpsState> ParseInternal(rtc::BitBuffer* bit_buffer);
+  static absl::optional<VpsState> ParseInternal(
+      rtc::ArrayView<const uint8_t> buffer);
 };
 
 }  // namespace webrtc

--- a/logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
+++ b/logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
@@ -103,10 +103,8 @@ rtclog2::FrameDecodedEvents::Codec ConvertToProtoFormat(VideoCodecType codec) {
       return rtclog2::FrameDecodedEvents::CODEC_AV1;
     case VideoCodecType::kVideoCodecH264:
       return rtclog2::FrameDecodedEvents::CODEC_H264;
-#ifndef DISABLE_H265
     case VideoCodecType::kVideoCodecH265:
       return rtclog2::FrameDecodedEvents::CODEC_H265;
-#endif
     case VideoCodecType::kVideoCodecMultiplex:
       // This codec type is afaik not used.
       return rtclog2::FrameDecodedEvents::CODEC_UNKNOWN;

--- a/logging/rtc_event_log/rtc_event_log_parser.cc
+++ b/logging/rtc_event_log/rtc_event_log_parser.cc
@@ -315,7 +315,7 @@ VideoCodecType GetRuntimeCodecType(rtclog2::FrameDecodedEvents::Codec codec) {
       return VideoCodecType::kVideoCodecAV1;
     case rtclog2::FrameDecodedEvents::CODEC_H264:
       return VideoCodecType::kVideoCodecH264;
-#ifndef DISABLE_H265 
+#ifdef WEBRTC_USE_H265 
     case rtclog2::FrameDecodedEvents::CODEC_H265:
       return VideoCodecType::kVideoCodecH265;
 #endif 

--- a/media/base/media_constants.cc
+++ b/media/base/media_constants.cc
@@ -104,7 +104,7 @@ const char kVp8CodecName[] = "VP8";
 const char kVp9CodecName[] = "VP9";
 const char kAv1CodecName[] = "AV1";
 const char kH264CodecName[] = "H264";
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 const char kH265CodecName[] = "H265";
 #endif
 
@@ -116,7 +116,7 @@ const char kH264FmtpSpropParameterSets[] = "sprop-parameter-sets";
 const char kH264FmtpSpsPpsIdrInKeyframe[] = "sps-pps-idr-in-keyframe";
 const char kH264ProfileLevelConstrainedBaseline[] = "42e01f";
 const char kH264ProfileLevelConstrainedHigh[] = "640c1f";
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 // RFC 7798 RTP Payload Format for H.265 video
 const char kH265FmtpProfileSpace[] = "profile-space";
 const char kH265FmtpProfileId[] = "profile-id";

--- a/media/base/media_constants.h
+++ b/media/base/media_constants.h
@@ -124,7 +124,7 @@ RTC_EXPORT extern const char kVp8CodecName[];
 RTC_EXPORT extern const char kVp9CodecName[];
 RTC_EXPORT extern const char kAv1CodecName[];
 RTC_EXPORT extern const char kH264CodecName[];
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 RTC_EXPORT extern const char kH265CodecName[];
 #endif
 
@@ -139,7 +139,7 @@ extern const char kH264ProfileLevelConstrainedHigh[];
 
 extern const char kVP9ProfileId[];
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 // RFC 7798 RTP Payload Format for H.265 video
 RTC_EXPORT extern const char kH265FmtpProfileSpace[];
 RTC_EXPORT extern const char kH265FmtpProfileId[];

--- a/modules/rtp_rtcp/BUILD.gn
+++ b/modules/rtp_rtcp/BUILD.gn
@@ -188,6 +188,8 @@ rtc_library("rtp_rtcp") {
     "source/rtp_format.h",
     "source/rtp_format_h264.cc",
     "source/rtp_format_h264.h",
+    "source/rtp_format_h265.cc",
+    "source/rtp_format_h265.h",
     "source/rtp_format_video_generic.cc",
     "source/rtp_format_video_generic.h",
     "source/rtp_format_vp8.cc",
@@ -237,6 +239,8 @@ rtc_library("rtp_rtcp") {
     "source/video_rtp_depacketizer_generic.h",
     "source/video_rtp_depacketizer_h264.cc",
     "source/video_rtp_depacketizer_h264.h",
+    "source/video_rtp_depacketizer_h265.cc",
+    "source/video_rtp_depacketizer_h265.h",
     "source/video_rtp_depacketizer_raw.cc",
     "source/video_rtp_depacketizer_raw.h",
     "source/video_rtp_depacketizer_vp8.cc",
@@ -249,19 +253,6 @@ rtc_library("rtp_rtcp") {
     defines = [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=1" ]
   } else {
     defines = [ "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0" ]
-  }
-
-  if (rtc_use_h265) {
-    sources += [
-      "source/rtp_format_h265.cc",
-      "source/rtp_format_h265.h",
-      "source/video_rtp_depacketizer_h265.cc",
-      "source/video_rtp_depacketizer_h265.h",
-    ]
-  }
-
-  if (!rtc_use_h265) {
-    defines += ["DISABLE_H265"]
   }
 
   deps = [

--- a/modules/rtp_rtcp/source/create_video_rtp_depacketizer.cc
+++ b/modules/rtp_rtcp/source/create_video_rtp_depacketizer.cc
@@ -19,9 +19,8 @@
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer_h264.h"
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer_vp8.h"
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer_vp9.h"
-#ifndef DISABLE_H265
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer_h265.h"
-#endif
+
 namespace webrtc {
 
 std::unique_ptr<VideoRtpDepacketizer> CreateVideoRtpDepacketizer(
@@ -33,10 +32,8 @@ std::unique_ptr<VideoRtpDepacketizer> CreateVideoRtpDepacketizer(
       return std::make_unique<VideoRtpDepacketizerVp8>();
     case kVideoCodecVP9:
       return std::make_unique<VideoRtpDepacketizerVp9>();
-#ifndef DISABLE_H265
     case kVideoCodecH265:
-	  return std::make_unique<VideoRtpDepacketizerH265>();
-#endif
+      return std::make_unique<VideoRtpDepacketizerH265>();
     case kVideoCodecAV1:
       return std::make_unique<VideoRtpDepacketizerAv1>();
     case kVideoCodecGeneric:

--- a/modules/rtp_rtcp/source/rtp_format.cc
+++ b/modules/rtp_rtcp/source/rtp_format.cc
@@ -14,17 +14,13 @@
 
 #include "absl/types/variant.h"
 #include "modules/rtp_rtcp/source/rtp_format_h264.h"
-#ifndef DISABLE_H265
 #include "modules/rtp_rtcp/source/rtp_format_h265.h"
-#endif
 #include "modules/rtp_rtcp/source/rtp_format_video_generic.h"
 #include "modules/rtp_rtcp/source/rtp_format_vp8.h"
 #include "modules/rtp_rtcp/source/rtp_format_vp9.h"
 #include "modules/rtp_rtcp/source/rtp_packetizer_av1.h"
 #include "modules/video_coding/codecs/h264/include/h264_globals.h"
-#ifndef DISABLE_H265
 #include "modules/video_coding/codecs/h265/include/h265_globals.h"
-#endif
 #include "modules/video_coding/codecs/vp8/include/vp8_globals.h"
 #include "modules/video_coding/codecs/vp9/include/vp9_globals.h"
 #include "rtc_base/checks.h"
@@ -49,7 +45,7 @@ std::unique_ptr<RtpPacketizer> RtpPacketizer::Create(
       return std::make_unique<RtpPacketizerH264>(payload, limits,
                                                  h264.packetization_mode);
     }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265: {
       const auto& h265 =
           absl::get<RTPVideoHeaderH265>(rtp_video_header.video_type_header);

--- a/modules/rtp_rtcp/source/rtp_format_h265.h
+++ b/modules/rtp_rtcp/source/rtp_format_h265.h
@@ -21,7 +21,6 @@
 #include "modules/rtp_rtcp/source/rtp_format.h"
 #include "modules/video_coding/codecs/h265/include/h265_globals.h"
 #include "rtc_base/buffer.h"
-#include "rtc_base/constructor_magic.h"
 
 namespace webrtc {
 
@@ -33,7 +32,10 @@ class RtpPacketizerH265 : public RtpPacketizer {
                     PayloadSizeLimits limits,
                     H265PacketizationMode packetization_mode);
 
-   ~RtpPacketizerH265() override;
+  ~RtpPacketizerH265() override;
+
+  RtpPacketizerH265(const RtpPacketizerH265&) = delete;
+  RtpPacketizerH265& operator=(const RtpPacketizerH265&) = delete;
 
   size_t NumPackets() const override;
 
@@ -100,8 +102,6 @@ class RtpPacketizerH265 : public RtpPacketizer {
 
   const PayloadSizeLimits limits_;
   size_t num_packets_left_;
-
-  RTC_DISALLOW_COPY_AND_ASSIGN(RtpPacketizerH265);
 };
 }  // namespace webrtc
 #endif  // WEBRTC_MODULES_RTP_RTCP_SOURCE_RTP_FORMAT_H265_H_

--- a/modules/rtp_rtcp/source/rtp_sender_video.cc
+++ b/modules/rtp_rtcp/source/rtp_sender_video.cc
@@ -815,9 +815,7 @@ uint8_t RTPSenderVideo::GetTemporalId(const RTPVideoHeader& header) {
     uint8_t operator()(const RTPVideoHeaderLegacyGeneric&) {
       return kNoTemporalIdx;
     }
-#ifndef DISABLE_H265
     uint8_t operator()(const RTPVideoHeaderH265&) { return kNoTemporalIdx; }
-#endif
     uint8_t operator()(const absl::monostate&) { return kNoTemporalIdx; }
   };
   return absl::visit(TemporalIdGetter(), header.video_type_header);

--- a/modules/rtp_rtcp/source/rtp_video_header.h
+++ b/modules/rtp_rtcp/source/rtp_video_header.h
@@ -25,9 +25,7 @@
 #include "api/video/video_rotation.h"
 #include "api/video/video_timing.h"
 #include "modules/video_coding/codecs/h264/include/h264_globals.h"
-#ifndef DISABLE_H265
 #include "modules/video_coding/codecs/h265/include/h265_globals.h"
-#endif
 #include "modules/video_coding/codecs/vp8/include/vp8_globals.h"
 #include "modules/video_coding/codecs/vp9/include/vp9_globals.h"
 
@@ -39,20 +37,12 @@ struct RTPVideoHeaderLegacyGeneric {
   uint16_t picture_id;
 };
 
-#ifndef DISABLE_H265
 using RTPVideoTypeHeader = absl::variant<absl::monostate,
                                          RTPVideoHeaderVP8,
                                          RTPVideoHeaderVP9,
                                          RTPVideoHeaderH264,
                                          RTPVideoHeaderH265,
-										 RTPVideoHeaderLegacyGeneric>;
-#else
-using RTPVideoTypeHeader = absl::variant<absl::monostate,
-                                         RTPVideoHeaderVP8,
-                                         RTPVideoHeaderVP9,
-                                         RTPVideoHeaderH264,
-										 RTPVideoHeaderLegacyGeneric>;
-#endif
+                                         RTPVideoHeaderLegacyGeneric>;
 
 struct RTPVideoHeader {
   struct GenericDescriptorInfo {

--- a/modules/rtp_rtcp/source/video_rtp_depacketizer_h265.cc
+++ b/modules/rtp_rtcp/source/video_rtp_depacketizer_h265.cc
@@ -25,6 +25,7 @@
 #include "common_video/h265/h265_vps_parser.h"
 #include "modules/rtp_rtcp/source/byte_io.h"
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer.h"
+#include "modules/video_coding/codecs/h265/include/h265_globals.h"
 #include "rtc_base/checks.h"
 #include "rtc_base/copy_on_write_buffer.h"
 #include "rtc_base/logging.h"
@@ -296,15 +297,14 @@ absl::optional<VideoRtpDepacketizer::ParsedRtpPayload> ParseFuNalu(
              "unit with original type: "
           << static_cast<int>(nalu.type);
     }
-	rtp_payload =
-	    rtp_payload.Slice(1, rtp_payload.size() - 1);
-    rtp_payload[0] = f | original_nal_type << 1 | layer_id_h;
-    rtp_payload[1] = layer_id_l_unshifted | tid;
-	parsed_payload->video_payload = std::move(rtp_payload);
+    rtp_payload = rtp_payload.Slice(1, rtp_payload.size() - 1);
+    rtp_payload.MutableData()[0] = f | original_nal_type << 1 | layer_id_h;
+    rtp_payload.MutableData()[1] = layer_id_l_unshifted | tid;
+    parsed_payload->video_payload = std::move(rtp_payload);
   } else {
-	 parsed_payload->video_payload =
-        rtp_payload.Slice(kHevcNalHeaderSize + kHevcFuHeaderSize,
-		rtp_payload.size() - kHevcNalHeaderSize - kHevcFuHeaderSize);
+    parsed_payload->video_payload = rtp_payload.Slice(
+        kHevcNalHeaderSize + kHevcFuHeaderSize,
+        rtp_payload.size() - kHevcNalHeaderSize - kHevcFuHeaderSize);
   }
 
   if (original_nal_type == H265::NaluType::kIdrWRadl

--- a/modules/video_coding/codecs/h265/include/h265_globals.h
+++ b/modules/video_coding/codecs/h265/include/h265_globals.h
@@ -14,8 +14,6 @@
 #ifndef MODULES_VIDEO_CODING_CODECS_H265_INCLUDE_H265_GLOBALS_H_
 #define MODULES_VIDEO_CODING_CODECS_H265_INCLUDE_H265_GLOBALS_H_
 
-#ifndef DISABLE_H265
-
 #include "modules/video_coding/codecs/h264/include/h264_globals.h"
 
 namespace webrtc {
@@ -56,7 +54,5 @@ struct RTPVideoHeaderH265 {
 };
 
 }  // namespace webrtc
-
-#endif
 
 #endif  // MODULES_VIDEO_CODING_CODECS_H265_INCLUDE_H265_GLOBALS_H_

--- a/modules/video_coding/codecs/multiplex/multiplex_encoder_adapter.cc
+++ b/modules/video_coding/codecs/multiplex/multiplex_encoder_adapter.cc
@@ -93,12 +93,10 @@ int MultiplexEncoderAdapter::InitEncode(
       key_frame_interval_ = video_codec.H264()->keyFrameInterval;
       video_codec.H264()->keyFrameInterval = 0;
       break;
-#ifndef DISABLE_H265
     case kVideoCodecH265:
       key_frame_interval_ = video_codec.H265()->keyFrameInterval;
       video_codec.H265()->keyFrameInterval = 0;
       break;
-#endif
     default:
       break;
   }

--- a/modules/video_coding/encoded_frame.cc
+++ b/modules/video_coding/encoded_frame.cc
@@ -140,7 +140,7 @@ void VCMEncodedFrame::CopyCodecSpecific(const RTPVideoHeader* header) {
         _codecSpecificInfo.codecType = kVideoCodecAV1;
         break;
       }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       case kVideoCodecH265: {
         _codecSpecificInfo.codecType = kVideoCodecH265;
         break;

--- a/modules/video_coding/include/video_codec_interface.h
+++ b/modules/video_coding/include/video_codec_interface.h
@@ -20,7 +20,7 @@
 #include "api/video_codecs/video_encoder.h"
 #include "common_video/generic_frame_descriptor/generic_frame_info.h"
 #include "modules/video_coding/codecs/h264/include/h264_globals.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "modules/video_coding/codecs/h265/include/h265_globals.h"
 #endif
 #include "modules/video_coding/codecs/vp9/include/vp9_globals.h"
@@ -94,7 +94,7 @@ struct CodecSpecificInfoH264 {
   bool idr_frame;
 };
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 struct CodecSpecificInfoH265 {
   H265PacketizationMode packetization_mode;
   bool idr_frame;
@@ -107,7 +107,7 @@ union CodecSpecificInfoUnion {
   CodecSpecificInfoVP8 VP8;
   CodecSpecificInfoVP9 VP9;
   CodecSpecificInfoH264 H264;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   CodecSpecificInfoH265 H265;
 #endif
 };

--- a/modules/video_coding/jitter_buffer_common.h
+++ b/modules/video_coding/jitter_buffer_common.h
@@ -54,7 +54,7 @@ enum VCMFrameBufferStateEnum {
 };
 
 enum { kH264StartCodeLengthBytes = 4 };
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 enum { kH265StartCodeLengthBytes = 4 };
 #endif
 }  // namespace webrtc

--- a/modules/video_coding/packet.cc
+++ b/modules/video_coding/packet.cc
@@ -44,7 +44,7 @@ VCMPacket::VCMPacket(const uint8_t* ptr,
       markerBit(rtp_header.markerBit),
       timesNacked(-1),
       completeNALU(kNaluIncomplete),
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       insertStartCode((videoHeader.codec == kVideoCodecH264 || videoHeader.codec == kVideoCodecH265) &&
                       videoHeader.is_first_packet_in_frame),
 #else

--- a/modules/video_coding/packet_buffer.cc
+++ b/modules/video_coding/packet_buffer.cc
@@ -23,14 +23,14 @@
 #include "api/rtp_packet_info.h"
 #include "api/video/video_frame_type.h"
 #include "common_video/h264/h264_common.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "common_video/h265/h265_common.h"
 #endif
 #include "modules/rtp_rtcp/source/rtp_header_extensions.h"
 #include "modules/rtp_rtcp/source/rtp_packet_received.h"
 #include "modules/rtp_rtcp/source/rtp_video_header.h"
 #include "modules/video_coding/codecs/h264/include/h264_globals.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "modules/video_coding/codecs/h265/include/h265_globals.h"
 #endif
 #include "rtc_base/checks.h"
@@ -268,7 +268,7 @@ std::vector<std::unique_ptr<PacketBuffer::Packet>> PacketBuffer::FindFrames(
       bool has_h264_idr = false;
       bool is_h264_keyframe = false;
       bool is_h265 = false;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       is_h265 = buffer_[start_index]->codec() == kVideoCodecH265;
       bool has_h265_sps = false;
       bool has_h265_pps = false;
@@ -320,7 +320,7 @@ std::vector<std::unique_ptr<PacketBuffer::Packet>> PacketBuffer::FindFrames(
             }
           }
         }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
         if (is_h265 && !is_h265_keyframe) {
           const auto* h265_header = absl::get_if<RTPVideoHeaderH265>(
               &buffer_[start_index]->video_header.video_type_header);
@@ -405,7 +405,7 @@ std::vector<std::unique_ptr<PacketBuffer::Packet>> PacketBuffer::FindFrames(
         }
       }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       if (is_h265) {
         // Warn if this is an unsafe frame.
         if (has_h265_idr && (!has_h265_sps || !has_h265_pps)) {

--- a/modules/video_coding/session_info.cc
+++ b/modules/video_coding/session_info.cc
@@ -145,7 +145,7 @@ std::vector<NaluInfo> VCMSessionInfo::GetNaluInfos() const {
   }
   return nalu_infos;
 }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 std::vector<H265NaluInfo> VCMSessionInfo::GetH265NaluInfos() const {
   if (packets_.empty() || packets_.front().video_header.codec != kVideoCodecH265)
     return std::vector<H265NaluInfo>();
@@ -219,7 +219,7 @@ size_t VCMSessionInfo::InsertBuffer(uint8_t* frame_buffer,
   // TODO(pbos): Remove H264 parsing from this step and use a fragmentation
   // header supplied by the H264 depacketizer.
   const size_t kH264NALHeaderLengthInBytes = 1;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   const size_t kH265NALHeaderLengthInBytes = 2;
   const auto* h265 =
       absl::get_if<RTPVideoHeaderH265>(&packet.video_header.video_type_header);
@@ -249,7 +249,7 @@ size_t VCMSessionInfo::InsertBuffer(uint8_t* frame_buffer,
     packet.sizeBytes = required_length;
     return packet.sizeBytes;
   }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   else if (h265 && h265->packetization_type == kH265AP) {
     // Similar to H264, for H265 aggregation packets, we rely on jitter buffer
     // to remove the two length bytes between each NAL unit, and potentially add
@@ -508,7 +508,7 @@ int VCMSessionInfo::InsertPacket(const VCMPacket& packet,
          IsNewerSequenceNumber(packet.seqNum, last_packet_seq_num_))) {
       last_packet_seq_num_ = packet.seqNum;
     }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   } else if (packet.codec() == kVideoCodecH265) {
     frame_type_ = packet.video_header.frame_type;
     if (packet.is_first_packet_in_frame() &&

--- a/modules/video_coding/session_info.h
+++ b/modules/video_coding/session_info.h
@@ -64,7 +64,7 @@ class VCMSessionInfo {
   int Tl0PicId() const;
 
   std::vector<NaluInfo> GetNaluInfos() const;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   std::vector<H265NaluInfo> GetH265NaluInfos() const;
 #endif
 

--- a/rtc_base/experiments/min_video_bitrate_experiment.cc
+++ b/rtc_base/experiments/min_video_bitrate_experiment.cc
@@ -100,9 +100,7 @@ absl::optional<DataRate> GetExperimentalMinVideoBitrate(VideoCodecType type) {
         return min_bitrate_av1.GetOptional();
       case kVideoCodecH264:
         return min_bitrate_h264.GetOptional();
-#ifndef DISABLE_H265
       case kVideoCodecH265:
-#endif
       case kVideoCodecGeneric:
       case kVideoCodecMultiplex:
         return absl::nullopt;

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -708,7 +708,6 @@ if (is_ios || is_mac) {
       ]
 
       if (rtc_use_h265) {
-        assert(false)
         sources += [
           "objc/components/video_codec/RTCCodecSpecificInfoH265.h",
           "objc/components/video_codec/RTCCodecSpecificInfoH265.mm",
@@ -1364,16 +1363,6 @@ if (is_ios || is_mac) {
           "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.h",
         ]
 
-        if (rtc_use_h265) {
-          sources += [
-            "objc/components/video_codec/RTCH265ProfileLevelId.h",
-            "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
-            "objc/components/video_codec/RTCVideoDecoderH265.h",
-            "objc/components/video_codec/RTCVideoEncoderFactoryH265.h",
-            "objc/components/video_codec/RTCVideoEncoderH265.h",
-          ]
-        }
-
         if (!build_with_chromium) {
           common_objc_headers += [
             "objc/api/logging/RTCCallbackLogger.h",
@@ -1383,6 +1372,16 @@ if (is_ios || is_mac) {
 
         sources = common_objc_headers
         public_headers = common_objc_headers
+
+        if (rtc_use_h265) {
+          sources += [
+            "objc/components/video_codec/RTCH265ProfileLevelId.h",
+            "objc/components/video_codec/RTCVideoDecoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoDecoderH265.h",
+            "objc/components/video_codec/RTCVideoEncoderFactoryH265.h",
+            "objc/components/video_codec/RTCVideoEncoderH265.h",
+          ]
+        }
 
         ldflags = [
           "-all_load",
@@ -1736,6 +1735,7 @@ if (is_ios || is_mac) {
     rtc_library("videotoolbox_objc") {
       visibility = [ "*" ]
       allow_poison = [ "audio_codecs" ]  # TODO(bugs.webrtc.org/8396): Remove.
+      defines = []
       sources = [
         "objc/components/video_codec/RTCVideoDecoderFactoryH264.h",
         "objc/components/video_codec/RTCVideoDecoderFactoryH264.m",
@@ -1758,6 +1758,7 @@ if (is_ios || is_mac) {
           "objc/components/video_codec/RTCVideoEncoderH265.h",
           "objc/components/video_codec/RTCVideoEncoderH265.mm",
         ]
+        defines += ["WEBRTC_USE_H265"]
       }
 
       configs += [
@@ -1766,7 +1767,7 @@ if (is_ios || is_mac) {
       ]
 
       if (is_ios && rtc_apprtcmobile_broadcast_extension) {
-        defines = [ "RTC_APPRTCMOBILE_BROADCAST_EXTENSION" ]
+        defines += [ "RTC_APPRTCMOBILE_BROADCAST_EXTENSION" ]
       }
 
       deps = [

--- a/sdk/android/src/jni/video_encoder_wrapper.cc
+++ b/sdk/android/src/jni/video_encoder_wrapper.cc
@@ -13,7 +13,7 @@
 #include <utility>
 
 #include "common_video/h264/h264_common.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "common_video/h265/h265_common.h"
 #endif
 #include "modules/video_coding/include/video_codec_interface.h"
@@ -353,7 +353,7 @@ int VideoEncoderWrapper::ParseQp(rtc::ArrayView<const uint8_t> buffer) {
       qp = h264_bitstream_parser_.GetLastSliceQp().value_or(-1);
       success = (qp >= 0);
       break;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265:
       success = h265_bitstream_parser_.GetLastSliceQp(&qp);
       break;

--- a/sdk/android/src/jni/video_encoder_wrapper.h
+++ b/sdk/android/src/jni/video_encoder_wrapper.h
@@ -21,7 +21,7 @@
 #include "absl/types/optional.h"
 #include "api/video_codecs/video_encoder.h"
 #include "common_video/h264/h264_bitstream_parser.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "common_video/h265/h265_bitstream_parser.h"
 #endif
 #include "modules/video_coding/codecs/vp9/include/vp9_globals.h"
@@ -107,7 +107,7 @@ class VideoEncoderWrapper : public VideoEncoder {
   VideoCodec codec_settings_;
   EncoderInfo encoder_info_;
   H264BitstreamParser h264_bitstream_parser_;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   H265BitstreamParser h265_bitstream_parser_;
 #endif
 

--- a/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
@@ -20,7 +20,7 @@
 #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
 #import "api/video_codec/RTCVideoDecoderAV1.h"  // nogncheck
 #endif
-#if !defined(DISABLE_H265)
+#ifdef WEBRTC_USE_H265
 #import "RTCH265ProfileLevelId.h"
 #import "RTCVideoDecoderH265.h"
 #endif
@@ -48,16 +48,18 @@
 
   RTC_OBJC_TYPE(RTCVideoCodecInfo) *vp8Info =
       [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp8Name];
-  
-#if !defined(DISABLE_H265)
+
+#ifdef WEBRTC_USE_H265
   RTCVideoCodecInfo *h265Info = [[RTCVideoCodecInfo alloc] initWithName:kRTCVideoCodecH265Name];
 #endif
 
   NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *result = [@[
-
     constrainedHighInfo,
     constrainedBaselineInfo,
     vp8Info,
+#ifdef WEBRTC_USE_H265
+    h265Info,
+#endif
   ] mutableCopy];
 
   if ([RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
@@ -69,8 +71,8 @@
   [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name]];
 #endif
 
-#if !defined(DISABLE_H265)
-  [result addObject:h265Info],
+#if defined(RTC_USE_H265)
+  [result addObject:h265Info];
 #endif
 
   return result;
@@ -91,7 +93,7 @@
     return [RTC_OBJC_TYPE(RTCVideoDecoderAV1) av1Decoder];
   }
 #endif
-#if !defined(DISABLE_H265)
+#ifdef WEBRTC_USE_H265
   if (@available(iOS 11, *)) {
     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
       return [[RTCVideoDecoderH265 alloc] init];

--- a/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
+++ b/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
@@ -20,7 +20,7 @@
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
 #import "api/video_codec/RTCVideoEncoderAV1.h"  // nogncheck
 #endif
-#if !defined(DISABLE_H265)
+#ifdef WEBRTC_USE_H265
 #import "RTCH265ProfileLevelId.h"
 #import "RTCVideoEncoderH265.h"
 #endif
@@ -65,7 +65,7 @@
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
   [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name]];
 #endif
-#if !defined(DISABLE_H265)
+#ifdef WEBRTC_USE_H265
   RTCVideoCodecInfo *h265Info = [[RTCVideoCodecInfo alloc] initWithName:kRTCVideoCodecH265Name];
   [result addObject:h265Info];
 #endif
@@ -81,7 +81,7 @@
   } else if ([info.name isEqualToString:kRTCVideoCodecVp9Name] &&
              [RTC_OBJC_TYPE(RTCVideoEncoderVP9) isSupported]) {
     return [RTC_OBJC_TYPE(RTCVideoEncoderVP9) vp9Encoder];
-#if !defined(DISABLE_H265)
+#ifdef WEBRTC_USE_H265
   } else if (@available(iOS 11, *)) {
     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
       return [[RTCVideoEncoderH265 alloc] initWithCodecInfo:info];

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -128,9 +128,10 @@ void h265DecompressionOutputCallback(void* decoder,
     return WEBRTC_VIDEO_CODEC_ERROR;
   }
   CMSampleBufferRef sampleBuffer = nullptr;
-  if (!webrtc::H265AnnexBBufferToCMSampleBuffer(
-          (uint8_t*)inputImage.buffer.bytes, inputImage.buffer.length,
-          _videoFormat, &sampleBuffer)) {
+  if (!webrtc::H265AnnexBBufferToCMSampleBuffer((uint8_t*)inputImage.buffer.bytes,
+                                                inputImage.buffer.length,
+                                                _videoFormat,
+                                                &sampleBuffer)) {
     return WEBRTC_VIDEO_CODEC_ERROR;
   }
   RTC_DCHECK(sampleBuffer);

--- a/sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -224,7 +224,7 @@ bool H264AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
   return true;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 bool H265CMSampleBufferToAnnexBBuffer(
     CMSampleBufferRef hvcc_sample_buffer,
     bool is_keyframe,
@@ -466,7 +466,7 @@ CMVideoFormatDescriptionRef CreateVideoFormatDescription(
   return description;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
     const uint8_t* annexb_buffer,
     size_t annexb_buffer_size) {
@@ -550,7 +550,7 @@ bool AnnexBBufferReader::SeekToNextNaluOfType(NaluType type) {
   return false;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 bool AnnexBBufferReader::SeekToNextNaluOfType(H265::NaluType type) {
   for (; offset_ != offsets_.end(); ++offset_) {
     if (offset_->payload_size < 1)

--- a/sdk/objc/components/video_codec/nalu_rewriter.h
+++ b/sdk/objc/components/video_codec/nalu_rewriter.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "common_video/h264/h264_common.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "common_video/h265/h265_common.h"
 #endif
 #include "modules/include/module_common_types.h"
@@ -47,7 +47,7 @@ bool H264AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
                                       CMSampleBufferRef* out_sample_buffer,
                                       CMMemoryPoolRef memory_pool);
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 // Converts a sample buffer emitted from the VideoToolbox encoder into a buffer
 // suitable for RTP. The sample buffer is in hvcc format whereas the rtp buffer
 // needs to be in Annex B format. Data is written directly to |annexb_buffer|
@@ -78,7 +78,7 @@ CMVideoFormatDescriptionRef CreateVideoFormatDescription(
     const uint8_t* annexb_buffer,
     size_t annexb_buffer_size);
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 CMVideoFormatDescriptionRef CreateH265VideoFormatDescription(
     const uint8_t* annexb_buffer,
     size_t annexb_buffer_size)
@@ -109,7 +109,7 @@ class AnnexBBufferReader final {
   // Return true if a NALU of the desired type is found, false if we
   // reached the end instead
   bool SeekToNextNaluOfType(H264::NaluType type);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   bool SeekToNextNaluOfType(H265::NaluType type);
 #endif
 

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -16,7 +16,7 @@
 #import "base/RTCVideoEncoder.h"
 #import "base/RTCVideoEncoderFactory.h"
 #import "components/video_codec/RTCCodecSpecificInfoH264+Private.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #import "components/video_codec/RTCCodecSpecificInfoH265+Private.h"
 #endif
 #import "sdk/objc/api/peerconnection/RTCEncodedImage+Private.h"
@@ -61,7 +61,7 @@ class ObjCVideoEncoder : public VideoEncoder {
         if ([info isKindOfClass:[RTC_OBJC_TYPE(RTCCodecSpecificInfoH264) class]]) {
           codecSpecificInfo =
               [(RTC_OBJC_TYPE(RTCCodecSpecificInfoH264) *)info nativeCodecSpecificInfo];
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       } else if ([info isKindOfClass:[RTC_OBJC_TYPE(RTCCodecSpecificInfoH265) class]]) {
         codecSpecificInfo = [(RTCCodecSpecificInfoH265 *)info nativeCodecSpecificInfo];
 #endif

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -940,7 +940,7 @@ rtc_library("rtc_expect_death") {
 rtc_library("run_loop") {
   visibility = [
     "../*",
-    "//talk/owt/*",
+    "//talk/owt/sdk/p2p/tests/*",
   ]
   testonly = true
   sources = [

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -420,6 +420,10 @@ rtc_library("fixed_fps_video_frame_writer_adapter") {
 }
 
 rtc_library("video_test_support") {
+  visibility = [
+    "../*",
+    "//talk/owt/sdk/p2p/tests/*",
+  ]
   testonly = true
 
   sources = [

--- a/test/scenario/video_stream.cc
+++ b/test/scenario/video_stream.cc
@@ -204,7 +204,7 @@ CreateH264SpecificSettings(VideoStreamConfig config) {
   return nullptr;
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 rtc::scoped_refptr<VideoEncoderConfig::EncoderSpecificSettings>
 CreateH265SpecificSettings(VideoStreamConfig config) {
   RTC_DCHECK_EQ(config.encoder.layers.temporal, 1);
@@ -223,7 +223,7 @@ rtc::scoped_refptr<VideoEncoderConfig::EncoderSpecificSettings>
 CreateEncoderSpecificSettings(VideoStreamConfig config) {
   using Codec = VideoStreamConfig::Encoder::Codec;
   switch (config.encoder.codec) {
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case Codec::kVideoCodecH265:
       return CreateH265SpecificSettings(config);
 #endif

--- a/test/video_codec_settings.h
+++ b/test/video_codec_settings.h
@@ -54,7 +54,7 @@ static void CodecSettings(VideoCodecType codec_type, VideoCodec* settings) {
     case kVideoCodecVP9:
       *(settings->VP9()) = VideoEncoder::GetDefaultVp9Settings();
       return;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265:
       *(settings->H265()) = VideoEncoder::GetDefaultH265Settings();
       return;

--- a/video/config/video_encoder_config.cc
+++ b/video/config/video_encoder_config.cc
@@ -112,7 +112,11 @@ void VideoEncoderConfig::EncoderSpecificSettings::FillVideoCodecVp9(
   RTC_DCHECK_NOTREACHED();
 }
 
-#ifndef DISABLE_H265
+void VideoEncoderConfig::EncoderSpecificSettings::FillVideoCodecH265(
+    VideoCodecH265* h265_settings) const {
+  RTC_DCHECK_NOTREACHED();
+}
+
 VideoEncoderConfig::H265EncoderSpecificSettings::H265EncoderSpecificSettings(
     const VideoCodecH265& specifics)
     : specifics_(specifics) {}
@@ -121,7 +125,6 @@ void VideoEncoderConfig::H265EncoderSpecificSettings::FillVideoCodecH265(
     VideoCodecH265* h265_settings) const {
   *h265_settings = specifics_;
 }
-#endif
 
 VideoEncoderConfig::Vp8EncoderSpecificSettings::Vp8EncoderSpecificSettings(
     const VideoCodecVP8& specifics)

--- a/video/config/video_encoder_config.h
+++ b/video/config/video_encoder_config.h
@@ -99,13 +99,12 @@ class VideoEncoderConfig {
 
     virtual void FillVideoCodecVp8(VideoCodecVP8* vp8_settings) const;
     virtual void FillVideoCodecVp9(VideoCodecVP9* vp9_settings) const;
+    virtual void FillVideoCodecH265(VideoCodecH265* h265_settings) const;
 
    private:
     ~EncoderSpecificSettings() override {}
     friend class VideoEncoderConfig;
   };
-
-#ifndef DISABLE_H265
   class H265EncoderSpecificSettings : public EncoderSpecificSettings {
    public:
     explicit H265EncoderSpecificSettings(const VideoCodecH265& specifics);
@@ -114,7 +113,6 @@ class VideoEncoderConfig {
    private:
     VideoCodecH265 specifics_;
   };
-#endif
   class Vp8EncoderSpecificSettings : public EncoderSpecificSettings {
    public:
     explicit Vp8EncoderSpecificSettings(const VideoCodecVP8& specifics);

--- a/video/rtp_video_stream_receiver2.cc
+++ b/video/rtp_video_stream_receiver2.cc
@@ -684,7 +684,7 @@ void RtpVideoStreamReceiver2::OnReceivedPayloadData(
         packet->video_payload = std::move(fixed.bitstream);
         break;
     }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   } else if (packet->codec() == kVideoCodecH265) {
     // Only when we start to receive packets will we know what payload type
     // that will be used. When we know the payload type insert the correct

--- a/video/rtp_video_stream_receiver2.h
+++ b/video/rtp_video_stream_receiver2.h
@@ -39,7 +39,7 @@
 #include "modules/rtp_rtcp/source/video_rtp_depacketizer.h"
 #include "modules/video_coding/h264_sps_pps_tracker.h"
 #include "modules/video_coding/loss_notification_controller.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "modules/video_coding/h265_vps_sps_pps_tracker.h"
 #endif
 #include "modules/video_coding/nack_requester.h"
@@ -397,7 +397,7 @@ class RtpVideoStreamReceiver2 : public LossNotificationSender,
   std::map<uint8_t, std::unique_ptr<VideoRtpDepacketizer>> payload_type_map_
       RTC_GUARDED_BY(packet_sequence_checker_);
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   video_coding::H265VpsSpsPpsTracker h265_tracker_;
 #endif
 

--- a/video/send_statistics_proxy.cc
+++ b/video/send_statistics_proxy.cc
@@ -47,7 +47,7 @@ enum HistogramCodecType {
   kVideoVp9 = 2,
   kVideoH264 = 3,
   kVideoAv1 = 4,
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   kVideoH265 = 5,
 #endif
   kVideoMax = 64,
@@ -79,7 +79,7 @@ HistogramCodecType PayloadNameToHistogramCodecType(
       return kVideoH264;
     case kVideoCodecAV1:
       return kVideoAv1;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265:
       return kVideoH265;
 #endif

--- a/video/video_stream_encoder.cc
+++ b/video/video_stream_encoder.cc
@@ -122,7 +122,7 @@ bool RequiresEncoderReset(const VideoCodec& prev_send_codec,
         return true;
       }
       break;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case kVideoCodecH265:
       if (new_send_codec.H265() != prev_send_codec.H265()) {
         return true;


### PR DESCRIPTION
This change enables HEVC support after rebasing to M108. HEVC related structures
are always declared, but the codec is only implemented when GN arg rtc_use_h265
is enabled (macro WEBRTC_USE_H265 is defined).