### PR TITLE
Fix C2362 error when build audio_device_core_win with MSVC.

### DIFF
--- a/modules/audio_device/win/audio_device_core_win.cc
+++ b/modules/audio_device/win/audio_device_core_win.cc
@@ -845,6 +845,8 @@ int32_t AudioDeviceWindowsCore::SpeakerVolumeIsAvailable(bool& available) {
   IAudioSessionManager* pManager = NULL;
   ISimpleAudioVolume* pVolume = NULL;
 
+  float volume(0.0f);
+
   hr = _ptrDeviceOut->Activate(__uuidof(IAudioSessionManager), CLSCTX_ALL, NULL,
                                (void**)&pManager);
   EXIT_ON_ERROR(hr);
@@ -852,7 +854,6 @@ int32_t AudioDeviceWindowsCore::SpeakerVolumeIsAvailable(bool& available) {
   hr = pManager->GetSimpleAudioVolume(NULL, FALSE, &pVolume);
   EXIT_ON_ERROR(hr);
 
-  float volume(0.0f);
   hr = pVolume->GetMasterVolume(&volume);
   if (FAILED(hr)) {
     available = false;
@@ -1031,12 +1032,13 @@ int32_t AudioDeviceWindowsCore::SetSpeakerMute(bool enable) {
   HRESULT hr = S_OK;
   IAudioEndpointVolume* pVolume = NULL;
 
+  const BOOL mute(enable);
+
   // Set the speaker system mute state.
   hr = _ptrDeviceOut->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
                                reinterpret_cast<void**>(&pVolume));
   EXIT_ON_ERROR(hr);
 
-  const BOOL mute(enable);
   hr = pVolume->SetMute(mute, NULL);
   EXIT_ON_ERROR(hr);
 
@@ -1138,12 +1140,13 @@ int32_t AudioDeviceWindowsCore::SetMicrophoneMute(bool enable) {
   HRESULT hr = S_OK;
   IAudioEndpointVolume* pVolume = NULL;
 
+  const BOOL mute(enable);
+
   // Set the microphone system mute state.
   hr = _ptrDeviceIn->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
                               reinterpret_cast<void**>(&pVolume));
   EXIT_ON_ERROR(hr);
 
-  const BOOL mute(enable);
   hr = pVolume->SetMute(mute, NULL);
   EXIT_ON_ERROR(hr);
 
@@ -1286,11 +1289,12 @@ int32_t AudioDeviceWindowsCore::MicrophoneVolumeIsAvailable(bool& available) {
   HRESULT hr = S_OK;
   IAudioEndpointVolume* pVolume = NULL;
 
+  float volume(0.0f);
+
   hr = _ptrDeviceIn->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
                               reinterpret_cast<void**>(&pVolume));
   EXIT_ON_ERROR(hr);
 
-  float volume(0.0f);
   hr = pVolume->GetMasterVolumeLevelScalar(&volume);
   if (FAILED(hr)) {
     available = false;
@@ -1878,6 +1882,11 @@ int32_t AudioDeviceWindowsCore::InitPlayout() {
   WAVEFORMATEX Wfx = WAVEFORMATEX();
   WAVEFORMATEX* pWfxClosestMatch = NULL;
 
+  UINT bufferFrameCount(0);
+  REFERENCE_TIME hnsBufferDuration =
+      0;  // ask for minimum buffer size (default)
+  const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000};
+
   // Create COM object with IAudioClient interface.
   SAFE_RELEASE(_ptrClientOut);
   hr = _ptrDeviceOut->Activate(__uuidof(IAudioClient), CLSCTX_ALL, NULL,
@@ -1911,7 +1920,6 @@ int32_t AudioDeviceWindowsCore::InitPlayout() {
   Wfx.wBitsPerSample = 16;
   Wfx.cbSize = 0;
 
-  const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000};
   hr = S_FALSE;
 
   // Iterate over frequencies and channels, in order of priority
@@ -1997,8 +2005,7 @@ int32_t AudioDeviceWindowsCore::InitPlayout() {
   // buffer.
   // ****************************************************************************
   //
-  REFERENCE_TIME hnsBufferDuration =
-      0;  // ask for minimum buffer size (default)
+
   if (_devicePlaySampleRate == 44100) {
     // Ask for a larger buffer size (30ms) when using 44.1kHz as render rate.
     // There seems to be a larger risk of underruns for 44.1 compared
@@ -2008,6 +2015,7 @@ int32_t AudioDeviceWindowsCore::InitPlayout() {
     // read by GetBufferSize() and it is 20ms on most machines.
     hnsBufferDuration = 30 * 10000;
   }
+
   hr = _ptrClientOut->Initialize(
       AUDCLNT_SHAREMODE_SHARED,  // share Audio Engine with other applications
       AUDCLNT_STREAMFLAGS_EVENTCALLBACK,  // processing of the audio buffer by
@@ -2038,7 +2046,6 @@ int32_t AudioDeviceWindowsCore::InitPlayout() {
 
   // Get the actual size of the shared (endpoint buffer).
   // Typical value is 960 audio frames <=> 20ms @ 48kHz sample rate.
-  UINT bufferFrameCount(0);
   hr = _ptrClientOut->GetBufferSize(&bufferFrameCount);
   if (SUCCEEDED(hr)) {
     RTC_LOG(LS_VERBOSE) << "IAudioClient::GetBufferSize() => "
@@ -2195,6 +2202,10 @@ int32_t AudioDeviceWindowsCore::InitRecording() {
   WAVEFORMATEXTENSIBLE Wfx = WAVEFORMATEXTENSIBLE();
   WAVEFORMATEX* pWfxClosestMatch = NULL;
 
+  UINT bufferFrameCount(0);
+
+  const int freqs[6] = {48000, 44100, 16000, 96000, 32000, 8000};
+
   // Create COM object with IAudioClient interface.
   SAFE_RELEASE(_ptrClientIn);
   hr = _ptrDeviceIn->Activate(__uuidof(IAudioClient), CLSCTX_ALL, NULL,
@@ -2231,7 +2242,6 @@ int32_t AudioDeviceWindowsCore::InitRecording() {
   Wfx.Samples.wValidBitsPerSample = Wfx.Format.wBitsPerSample;
   Wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
 
-  const int freqs[6] = {48000, 44100, 16000, 96000, 32000, 8000};
   hr = S_FALSE;
 
   // Iterate over frequencies and channels, in order of priority
@@ -2328,7 +2338,6 @@ int32_t AudioDeviceWindowsCore::InitRecording() {
 
   // Get the actual size of the shared (endpoint buffer).
   // Typical value is 960 audio frames <=> 20ms @ 48kHz sample rate.
-  UINT bufferFrameCount(0);
   hr = _ptrClientIn->GetBufferSize(&bufferFrameCount);
   if (SUCCEEDED(hr)) {
     RTC_LOG(LS_VERBOSE) << "IAudioClient::GetBufferSize() => "
@@ -2734,6 +2743,14 @@ DWORD AudioDeviceWindowsCore::DoRenderThread() {
   //
   UINT32 bufferLength = 0;
   hr = _ptrClientOut->GetBufferSize(&bufferLength);
+
+  REFERENCE_TIME devPeriod = 0;
+  REFERENCE_TIME devPeriodMin = 0;
+  double endpointBufferSizeMS =
+      10.0 * ((double)bufferLength / (double)_devicePlayBlockSize);
+  BYTE* pData = NULL;
+  int playout_delay = 0;
+
   EXIT_ON_ERROR(hr);
   RTC_LOG(LS_VERBOSE) << "[REND] size of buffer       : " << bufferLength;
 
@@ -2755,8 +2772,6 @@ DWORD AudioDeviceWindowsCore::DoRenderThread() {
   // an audio application can achieve. Typical value: 100000 <=> 0.01 sec =
   // 10ms.
   //
-  REFERENCE_TIME devPeriod = 0;
-  REFERENCE_TIME devPeriodMin = 0;
   _ptrClientOut->GetDevicePeriod(&devPeriod, &devPeriodMin);
   RTC_LOG(LS_VERBOSE) << "[REND] device period        : " << (DWORD)devPeriod
                       << " (" << (double)(devPeriod / 10000.0) << " ms)";
@@ -2764,20 +2779,17 @@ DWORD AudioDeviceWindowsCore::DoRenderThread() {
   // Derive initial rendering delay.
   // Example: 10*(960/480) + 15 = 20 + 15 = 35ms
   //
-  int playout_delay = 10 * (bufferLength / _playBlockSize) +
+  playout_delay = 10 * (bufferLength / _playBlockSize) +
                       (int)((latency + devPeriod) / 10000);
   _sndCardPlayDelay = playout_delay;
   _writtenSamples = 0;
   RTC_LOG(LS_VERBOSE) << "[REND] initial delay        : " << playout_delay;
 
-  double endpointBufferSizeMS =
-      10.0 * ((double)bufferLength / (double)_devicePlayBlockSize);
   RTC_LOG(LS_VERBOSE) << "[REND] endpointBufferSizeMS : "
                       << endpointBufferSizeMS;
 
   // Before starting the stream, fill the rendering buffer with silence.
   //
-  BYTE* pData = NULL;
   hr = _ptrRenderClient->GetBuffer(bufferLength, &pData);
   EXIT_ON_ERROR(hr);
 
@@ -3152,6 +3164,9 @@ DWORD AudioDeviceWindowsCore::DoCaptureThread() {
 
   _Lock();
 
+  double endpointBufferSizeMS = 0;
+  double extraDelayMS = 0;
+
   // Get size of capturing buffer (length is expressed as the number of audio
   // frames the buffer can hold). This value is fixed during the capturing
   // session.
@@ -3163,6 +3178,11 @@ DWORD AudioDeviceWindowsCore::DoCaptureThread() {
     return 1;
   }
   hr = _ptrClientIn->GetBufferSize(&bufferLength);
+
+  const UINT32 syncBufferSize = 2 * (bufferLength * _recAudioFrameSize);
+  REFERENCE_TIME devPeriod = 0;
+  REFERENCE_TIME devPeriodMin = 0;
+
   EXIT_ON_ERROR(hr);
   RTC_LOG(LS_VERBOSE) << "[CAPT] size of buffer       : " << bufferLength;
 
@@ -3170,7 +3190,6 @@ DWORD AudioDeviceWindowsCore::DoCaptureThread() {
   // It is used for compensation between native 44.1 and internal 44.0 and
   // for cases when the capture buffer is larger than 10ms.
   //
-  const UINT32 syncBufferSize = 2 * (bufferLength * _recAudioFrameSize);
   syncBuffer = new BYTE[syncBufferSize];
   if (syncBuffer == NULL) {
     return (DWORD)E_POINTER;
@@ -3189,16 +3208,14 @@ DWORD AudioDeviceWindowsCore::DoCaptureThread() {
   // Get the length of the periodic interval separating successive processing
   // passes by the audio engine on the data in the endpoint buffer.
   //
-  REFERENCE_TIME devPeriod = 0;
-  REFERENCE_TIME devPeriodMin = 0;
   _ptrClientIn->GetDevicePeriod(&devPeriod, &devPeriodMin);
   RTC_LOG(LS_VERBOSE) << "[CAPT] device period        : " << (DWORD)devPeriod
                       << " (" << (double)(devPeriod / 10000.0) << " ms)";
 
-  double extraDelayMS = (double)((latency + devPeriod) / 10000.0);
+  extraDelayMS = (double)((latency + devPeriod) / 10000.0);
   RTC_LOG(LS_VERBOSE) << "[CAPT] extraDelayMS         : " << extraDelayMS;
 
-  double endpointBufferSizeMS =
+  endpointBufferSizeMS =
       10.0 * ((double)bufferLength / (double)_recBlockSize);
   RTC_LOG(LS_VERBOSE) << "[CAPT] endpointBufferSizeMS : "
                       << endpointBufferSizeMS;
@@ -4012,6 +4029,10 @@ int32_t AudioDeviceWindowsCore::_EnumerateEndpointDevicesAll(
   IAudioEndpointVolume* pEndpointVolume = NULL;
   LPWSTR pwszID = NULL;
 
+  DWORD dwHwSupportMask = 0;
+  UINT count = 0;
+  UINT nChannelCount(0);
+
   // Generate a collection of audio endpoint devices in the system.
   // Get states for *all* endpoint devices.
   // Output: IMMDeviceCollection interface.
@@ -4023,8 +4044,6 @@ int32_t AudioDeviceWindowsCore::_EnumerateEndpointDevicesAll(
   EXIT_ON_ERROR(hr);
 
   // use the IMMDeviceCollection interface...
-
-  UINT count = 0;
 
   // Retrieve a count of the devices in the device collection.
   hr = pCollection->GetCount(&count);
@@ -4092,7 +4111,6 @@ int32_t AudioDeviceWindowsCore::_EnumerateEndpointDevicesAll(
                           << ")  : UNPLUGGED";
 
     // Check the hardware volume capabilities.
-    DWORD dwHwSupportMask = 0;
     hr = pEndpoint->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
                              (void**)&pEndpointVolume);
     CONTINUE_ON_ERROR(hr);
@@ -4113,7 +4131,6 @@ int32_t AudioDeviceWindowsCore::_EnumerateEndpointDevicesAll(
 
     // Check the channel count (#channels in the audio stream that enters or
     // leaves the audio endpoint device)
-    UINT nChannelCount(0);
     hr = pEndpointVolume->GetChannelCount(&nChannelCount);
     CONTINUE_ON_ERROR(hr);
     RTC_LOG(LS_VERBOSE) << "#channels    : " << nChannelCount;


### PR DESCRIPTION
Skipping initialization with a goto is not allowed. Move initialization before gotos.