### PR TITLE
Include <cwctype> in full_screen_win_application_handler.cc.

### DIFF
--- a/modules/desktop_capture/win/full_screen_win_application_handler.cc
+++ b/modules/desktop_capture/win/full_screen_win_application_handler.cc
@@ -11,6 +11,7 @@
 #include "modules/desktop_capture/win/full_screen_win_application_handler.h"
 
 #include <algorithm>
+#include <cwctype>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
`std::towupper` is defined in `<cwctype>`.