### PR TITLE
Remove macro INTEL_GPRA.

### DIFF
--- a/call/rtp_transport_controller_send.cc
+++ b/call/rtp_transport_controller_send.cc
@@ -558,12 +558,7 @@ void RtpTransportControllerSend::OnTransportFeedback(
                                                              feedback_time);
     if (feedback_msg) {
       if (controller_)
-#ifdef INTEL_GPRA
-      PostUpdates(controller_->OnTransportPacketsFeedback(
-          *feedback_msg, transport_feedback_adapter_.GetCurrentOffsetMs()));
-#else
-      PostUpdates(controller_->OnTransportPacketsFeedback(*feedback_msg, 0));
-#endif
+        PostUpdates(controller_->OnTransportPacketsFeedback(*feedback_msg, 0));
       // Only update outstanding data if any packet is first time acked.
       UpdateCongestedState();
     }

--- a/modules/congestion_controller/goog_cc/goog_cc_network_control.h
+++ b/modules/congestion_controller/goog_cc/goog_cc_network_control.h
@@ -73,11 +73,6 @@ class GoogCcNetworkController : public NetworkControllerInterface {
 
   NetworkControlUpdate GetNetworkState(Timestamp at_time) const;
 
-#if defined(INTEL_GPRA)
-  // Not implemented here?
-  void SetBitrateEstimationWindowSize(int init_window, int rate_window);
-#endif
-
  private:
   friend class GoogCcStatePrinter;
   std::vector<ProbeClusterConfig> ResetConstraints(

--- a/modules/congestion_controller/rtp/transport_feedback_adapter.cc
+++ b/modules/congestion_controller/rtp/transport_feedback_adapter.cc
@@ -61,12 +61,6 @@ DataSize InFlightBytesTracker::GetOutstandingData(
   }
 }
 
-#ifdef INTEL_GPRA
-int64_t TransportFeedbackAdapter::GetCurrentOffsetMs() {
-  return current_offset_ms_;
-}
-#endif
-
 // Comparator for consistent map with NetworkRoute as key.
 bool InFlightBytesTracker::NetworkRouteComparator::operator()(
     const rtc::NetworkRoute& a,
@@ -199,9 +193,6 @@ TransportFeedbackAdapter::ProcessTransportFeedbackInner(
   // time stamps.
   if (last_timestamp_.IsInfinite()) {
     current_offset_ = feedback_receive_time;
- #ifdef INTEL_GPRA
-    current_offset_ms_ = feedback_receive_time.ms();
- #endif
   } else {
     // TODO(srte): We shouldn't need to do rounding here.
     const TimeDelta delta = feedback.GetBaseDelta(last_timestamp_)
@@ -210,14 +201,8 @@ TransportFeedbackAdapter::ProcessTransportFeedbackInner(
     if (delta < Timestamp::Zero() - current_offset_) {
       RTC_LOG(LS_WARNING) << "Unexpected feedback timestamp received.";
       current_offset_ = feedback_receive_time;
-#ifdef INTEL_GPRA
-     current_offset_ms_ = feedback_receive_time.ms();
-#endif
     } else {
       current_offset_ += delta;
-#ifdef INTEL_GPRA
-      current_offset_ms_ += delta.ms();
-#endif
     }
   }
   last_timestamp_ = feedback.BaseTime();

--- a/modules/congestion_controller/rtp/transport_feedback_adapter.h
+++ b/modules/congestion_controller/rtp/transport_feedback_adapter.h
@@ -73,10 +73,6 @@ class TransportFeedbackAdapter {
 
   DataSize GetOutstandingData() const;
 
-#ifdef INTEL_GPRA
-  int64_t GetCurrentOffsetMs();
-#endif
-
  private:
   enum class SendTimeHistoryStatus { kNotAdded, kOk, kDuplicate };
 
@@ -93,9 +89,6 @@ class TransportFeedbackAdapter {
   // Sequence numbers are never negative, using -1 as it always < a real
   // sequence number.
   int64_t last_ack_seq_num_ = -1;
-#ifdef INTEL_GPRA
-  int64_t current_offset_ms_ = -1;
-#endif
   InFlightBytesTracker in_flight_;
 
   Timestamp current_offset_ = Timestamp::MinusInfinity();


### PR DESCRIPTION
This change also fixes a DCHECK failure because a field trial is behind the macro. Thus it's not used.