### PR TITLE
A workaround for MSVC internal compiler error.

### DIFF
--- a/api/test/metrics/metrics_logger.cc
+++ b/api/test/metrics/metrics_logger.cc
@@ -49,9 +49,11 @@ void DefaultMetricsLogger::LogSingleValueMetric(
       .improvement_direction = improvement_direction,
       .test_case = std::string(test_case_name),
       .metric_metadata = std::move(metadata),
+#ifndef _MSC_VER
       .time_series =
           Metric::TimeSeries{.samples = std::vector{Metric::TimeSeries::Sample{
                                  .timestamp = Now(), .value = value}}},
+#endif
       .stats = Metric::Stats{
           .mean = value, .stddev = absl::nullopt, .min = value, .max = value}});
 }

--- a/api/test/metrics/metrics_logger_and_exporter.cc
+++ b/api/test/metrics/metrics_logger_and_exporter.cc
@@ -61,9 +61,11 @@ void MetricsLoggerAndExporter::LogSingleValueMetric(
       .improvement_direction = improvement_direction,
       .test_case = std::string(test_case_name),
       .metric_metadata = std::move(metadata),
+#ifndef _MSC_VER
       .time_series =
           Metric::TimeSeries{.samples = std::vector{Metric::TimeSeries::Sample{
                                  .timestamp = Now(), .value = value}}},
+#endif
       .stats = Metric::Stats{
           .mean = value, .stddev = absl::nullopt, .min = value, .max = value}});
 }


### PR DESCRIPTION
MSVC reports fatal error C1001: Internal compiler error for Metric::TimeSeries::Sample's designated initialisation.