### PR TITLE
Pick "Reland "Change default NetEq sample rate to 48k.""

### DIFF
--- a/api/neteq/neteq.h
+++ b/api/neteq/neteq.h
@@ -128,7 +128,7 @@ class NetEq {
 
     std::string ToString() const;
 
-    int sample_rate_hz = 16000;  // Initial value. Will change with input data.
+    int sample_rate_hz = 48000;  // Initial value. Will change with input data.
     bool enable_post_decode_vad = false;
     size_t max_packets_in_buffer = 200;
     int max_delay_ms = 0;

--- a/modules/audio_coding/acm2/audio_coding_module_unittest.cc
+++ b/modules/audio_coding/acm2/audio_coding_module_unittest.cc
@@ -1030,7 +1030,7 @@ class AcmSenderBitExactnessNewApi : public AcmSenderBitExactnessOldApi {};
     defined(NDEBUG) && defined(WEBRTC_LINUX) && defined(WEBRTC_ARCH_X86_64)
 TEST_F(AcmSenderBitExactnessOldApi, IsacWb30ms) {
   ASSERT_NO_FATAL_FAILURE(SetUpTest("ISAC", 16000, 1, 103, 480, 480));
-  Run(/*audio_checksum_ref=*/"a3077ac01b0137e8bbc237fb1f9816a5",
+  Run(/*audio_checksum_ref=*/"37ecdabad1698a857cf811e6d1fa91df",
       /*payload_checksum_ref=*/"3c79f16f34218271f3dca4e2b1dfe1bb",
       /*expected_packets=*/33,
       /*expected_channels=*/test::AcmReceiveTestOldApi::kMonoOutput);
@@ -1038,7 +1038,7 @@ TEST_F(AcmSenderBitExactnessOldApi, IsacWb30ms) {
 
 TEST_F(AcmSenderBitExactnessOldApi, IsacWb60ms) {
   ASSERT_NO_FATAL_FAILURE(SetUpTest("ISAC", 16000, 1, 103, 960, 960));
-  Run(/*audio_checksum_ref=*/"76da9b7514f986fc2bb32b1c3170e8d4",
+  Run(/*audio_checksum_ref=*/"0e9078d23454901496a88362ba0740c3",
       /*payload_checksum_ref=*/"9e0a0ab743ad987b55b8e14802769c56",
       /*expected_packets=*/16,
       /*expected_channels=*/test::AcmReceiveTestOldApi::kMonoOutput);
@@ -1067,7 +1067,7 @@ TEST_F(AcmSenderBitExactnessOldApi, Pcm16_8000khz_10ms) {
 
 TEST_F(AcmSenderBitExactnessOldApi, Pcm16_16000khz_10ms) {
   ASSERT_NO_FATAL_FAILURE(SetUpTest("L16", 16000, 1, 108, 160, 160));
-  Run(/*audio_checksum_ref=*/"bc6ab94d12a464921763d7544fdbd07e",
+  Run(/*audio_checksum_ref=*/"f95c87bdd33f631bcf80f4b19445bbd2",
       /*payload_checksum_ref=*/"ad786526383178b08d80d6eee06e9bad",
       /*expected_packets=*/100,
       /*expected_channels=*/test::AcmReceiveTestOldApi::kMonoOutput);
@@ -1151,7 +1151,7 @@ TEST_F(AcmSenderBitExactnessOldApi, Ilbc_30ms) {
 #if defined(WEBRTC_LINUX) && defined(WEBRTC_ARCH_X86_64)
 TEST_F(AcmSenderBitExactnessOldApi, G722_20ms) {
   ASSERT_NO_FATAL_FAILURE(SetUpTest("G722", 16000, 1, 9, 320, 160));
-  Run(/*audio_checksum_ref=*/"a87a91ec0124510a64967f5d768554ff",
+  Run(/*audio_checksum_ref=*/"f5264affff25cf2cbd2e1e8a5217f9a3",
       /*payload_checksum_ref=*/"fc68a87e1380614e658087cb35d5ca10",
       /*expected_packets=*/50,
       /*expected_channels=*/test::AcmReceiveTestOldApi::kMonoOutput);


### PR DESCRIPTION
Description from original commit:

This is a reland of commit 38fcd58429b29c9474f1647efed7ebeb543c0637

Original change's description:
> Change default NetEq sample rate to 48k.
>
> This should avoid some resampling before any packets have been received given that the vast majority of devices use 48k sample rate and the most common codec is Opus (which we always decode in 48k).
>
> Bug: none
> Change-Id: Ie7baea57c3eb1b763a6460c3b06b56d67b2b258e
> Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/280662
> Commit-Queue: Jakob Ivarsson‎ <jakobi@webrtc.org>
> Reviewed-by: Henrik Lundin <henrik.lundin@webrtc.org>
> Cr-Commit-Position: refs/heads/main@{#38536}

Bug: none
Change-Id: Id634799286f6d1f1eaf315ebe8e70de669d589db
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/281900
Reviewed-by: Henrik Lundin <henrik.lundin@webrtc.org>
Commit-Queue: Jakob Ivarsson‎ <jakobi@webrtc.org>
Cr-Commit-Position: refs/heads/main@{#38572}