### PR TITLE
Restore some files for H.264.

### DIFF
--- a/modules/video_coding/BUILD.gn
+++ b/modules/video_coding/BUILD.gn
@@ -500,6 +500,10 @@ rtc_library("webrtc_h264") {
   visibility = [ "*" ]
   sources = [
     "codecs/h264/h264.cc",
+    "codecs/h264/h264_color_space.cc",
+    "codecs/h264/h264_color_space.h",
+    "codecs/h264/h264_decoder_impl.cc",
+    "codecs/h264/h264_decoder_impl.h",
     "codecs/h264/h264_encoder_impl.cc",
     "codecs/h264/h264_encoder_impl.h",
     "codecs/h264/include/h264.h",


### PR DESCRIPTION
These files were removed from GN during rebasing. Restore them for missing symbols.