### PR TITLE
fix decode HEVC format description

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession+Private.h
+++ b/sdk/objc/components/audio/RTCAudioSession+Private.h
@@ -79,6 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Notifies the receiver that there was an error when starting an audio unit. */
 - (void)notifyAudioUnitStartFailedWithError:(OSStatus)error;
 
+- (void)notifyDidChangeMicrophoneMute;
+
 // Properties and methods for tests.
 - (void)notifyDidBeginInterruption;
 - (void)notifyDidEndInterruptionWithShouldResumeSession:(BOOL)shouldResumeSession;

--- a/sdk/objc/components/audio/RTCAudioSession.h
+++ b/sdk/objc/components/audio/RTCAudioSession.h
@@ -102,6 +102,9 @@ RTC_OBJC_EXPORT
 - (void)audioSession:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession
     audioUnitStartFailedWithError:(NSError *)error;
 
+- (void)audioSession:(RTC_OBJC_TYPE(RTCAudioSession) *)audioSession
+    didChangeMicrophoneMute:(BOOL)isMicrophoneMute;
+
 @end
 
 /** This is a protocol used to inform RTCAudioSession when the audio session
@@ -181,6 +184,7 @@ RTC_OBJC_EXPORT
 @property(readonly) double preferredSampleRate;
 @property(readonly) NSInteger inputNumberOfChannels;
 @property(readonly) NSInteger outputNumberOfChannels;
+@property(readonly) BOOL isMicrophoneMute;
 @property(readonly) float outputVolume;
 @property(readonly) NSTimeInterval inputLatency;
 @property(readonly) NSTimeInterval outputLatency;

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -55,6 +55,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
   BOOL _isAudioEnabled;
   BOOL _canPlayOrRecord;
   BOOL _isInterrupted;
+  BOOL _isMicrophoneMute;
 }
 
 @synthesize session = _session;
@@ -676,6 +677,31 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
       return;
    }
    _isInterrupted = isInterrupted;
+  }
+}
+
+- (void)setIsMicrophoneMute:(BOOL)isMicrophoneMute {
+  @synchronized(self) {
+    if (_isMicrophoneMute == isMicrophoneMute) {
+      return;
+    }
+    _isMicrophoneMute = isMicrophoneMute;
+  }
+  [self notifyDidChangeMicrophoneMute];
+}
+
+- (BOOL)isMicrophoneMute {
+  @synchronized(self) {
+    return _isMicrophoneMute;
+  }
+}
+
+- (void)notifyDidChangeMicrophoneMute {
+  for (auto delegate : self.delegates) {
+    SEL sel = @selector(audioSession:didChangeMicrophoneMute:);
+    if ([delegate respondsToSelector:sel]) {
+      [delegate audioSession:self didChangeMicrophoneMute:self.isMicrophoneMute];
+    }
   }
 }
 

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.h
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.h
@@ -32,6 +32,7 @@ RTC_OBJC_EXPORT
 @property(nonatomic, assign) NSTimeInterval ioBufferDuration;
 @property(nonatomic, assign) NSInteger inputNumberOfChannels;
 @property(nonatomic, assign) NSInteger outputNumberOfChannels;
+@property(nonatomic, assign) BOOL isMicrophoneMute;
 
 /** Initializes configuration to defaults. */
 - (instancetype)init NS_DESIGNATED_INITIALIZER;

--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -62,6 +62,7 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
 @synthesize ioBufferDuration = _ioBufferDuration;
 @synthesize inputNumberOfChannels = _inputNumberOfChannels;
 @synthesize outputNumberOfChannels = _outputNumberOfChannels;
+@synthesize isMicrophoneMute = _isMicrophoneMute;
 
 - (instancetype)init {
   if (self = [super init]) {
@@ -96,6 +97,7 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
     // TODO(henrika): add support for stereo if needed.
     _inputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
     _outputNumberOfChannels = kRTCAudioSessionPreferredNumberOfChannels;
+    _isMicrophoneMute = true; // default set micriphone to mute
   }
   return self;
 }
@@ -115,6 +117,7 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
   config.ioBufferDuration = session.IOBufferDuration;
   config.inputNumberOfChannels = session.inputNumberOfChannels;
   config.outputNumberOfChannels = session.outputNumberOfChannels;
+  config.isMicrophoneMute = session.isMicrophoneMute;
   return config;
 }
 

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -86,4 +86,9 @@
   _observer->OnChangedOutputVolume();
 }
 
+- (void)audioSession:(RTCAudioSession *)session 
+    didChangeMicrophoneMute:(BOOL)isMicrophoneMute {
+  _observer->OnMicrophoneMuteChange(isMicrophoneMute);
+}
+
 @end

--- a/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -101,7 +101,7 @@ void h265DecompressionOutputCallback(void* decoder,
   }
 
   rtc::ScopedCFTypeRef<CMVideoFormatDescriptionRef> inputFormat =
-      rtc::ScopedCF(webrtc::CreateVideoFormatDescription(
+      rtc::ScopedCF(webrtc::CreateH265VideoFormatDescription(
           (uint8_t*)inputImage.buffer.bytes, inputImage.buffer.length));
   if (inputFormat) {
     CMVideoDimensions dimensions =

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -147,6 +147,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void OnValidRouteChange() override;
   void OnCanPlayOrRecordChange(bool can_play_or_record) override;
   void OnChangedOutputVolume() override;
+  void OnMicrophoneMuteChange(bool is_microphone_mute) override;
 
   // VoiceProcessingAudioUnitObserver methods.
   OSStatus OnDeliverRecordedData(AudioUnitRenderActionFlags* flags,
@@ -171,6 +172,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
   void HandleSampleRateChange();
   void HandlePlayoutGlitchDetected();
   void HandleOutputVolumeChange();
+  void HandleMicrophoneMuteChange(bool is_microphone_mute);
 
   // Uses current `playout_parameters_` and `record_parameters_` to inform the
   // audio device buffer (ADB) about our internal audio parameters.

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -1123,5 +1123,26 @@ int32_t AudioDeviceIOS::RecordingIsAvailable(bool& available) {
   return 0;
 }
 
+void AudioDeviceIOS::OnMicrophoneMuteChange(bool is_microphone_mute) {
+  RTC_DCHECK(thread_);
+  thread_->PostTask(SafeTask(safety_, [this, is_microphone_mute] { HandleMicrophoneMuteChange(is_microphone_mute); }));
+}
+
+void AudioDeviceIOS::HandleMicrophoneMuteChange(bool is_microphone_mute) {
+  RTC_DCHECK_RUN_ON(thread_);
+  RTCLog(@"Handling MicrophoneMute change to %d", is_microphone_mute);
+  if (is_microphone_mute) {
+    StopRecording();
+    StopPlayout();
+    InitPlayout();
+    StartPlayout();
+  } else {
+    StopPlayout();
+    InitRecording();
+    StartRecording();
+    StartPlayout();
+  }
+}
+
 }  // namespace ios_adm
 }  // namespace webrtc

--- a/sdk/objc/native/src/audio/audio_session_observer.h
+++ b/sdk/objc/native/src/audio/audio_session_observer.h
@@ -32,6 +32,8 @@ class AudioSessionObserver {
 
   virtual void OnChangedOutputVolume() = 0;
 
+  virtual void OnMicrophoneMuteChange(bool is_microphone_mute) = 0;
+
  protected:
   virtual ~AudioSessionObserver() {}
 };


### PR DESCRIPTION
If I change the script from `rtc_use_h265=false` to `rtc_use_h265=true`, I found the H265 decode is broken. I get the error message is "Missing video format. Frame with sps/pps required. ". So that is caused by the decoding the HEVC format not correctly.