### PR TITLE
Fix incorrect use of scoped enumerations in format strings

### DIFF
--- a/api/video_codecs/h264_profile_level_id.cc
+++ b/api/video_codecs/h264_profile_level_id.cc
@@ -238,7 +238,8 @@ absl::optional<std::string> H264ProfileLevelIdToString(
   }
 
   char str[7];
-  snprintf(str, 7u, "%s%02x", profile_idc_iop_string, profile_level_id.level);
+  snprintf(str, 7u, "%s%02x", profile_idc_iop_string,
+           static_cast<unsigned>(profile_level_id.level));
   return {str};
 }
 


### PR DESCRIPTION
Pick "Scoped enums do not get automatically promoted to their underlying type, so these uses have undefined behavior and Clang recently started warning about it."